### PR TITLE
Improve SoundSource Initialization + Subclassing Support

### DIFF
--- a/Assets/BroAudio/Runtime/MonoComponent/SoundSource.API.cs
+++ b/Assets/BroAudio/Runtime/MonoComponent/SoundSource.API.cs
@@ -9,7 +9,7 @@ namespace Ami.BroAudio
         /// <summary>
         /// Plays the audio base on the current PositionMode 
         /// </summary>
-        public void Play()
+        public virtual void Play()
         {
             switch (_positionMode)
             {
@@ -26,21 +26,21 @@ namespace Ami.BroAudio
         }
 
         ///<inheritdoc cref="BroAudio.Play(SoundID)"/>
-        public void PlayGlobally()
+        public virtual void PlayGlobally()
         {
             Stop();
             CurrentPlayer = BroAudio.Play(_sound, _overrideGroup);
         }
 
         ///<inheritdoc cref="BroAudio.Play(SoundID, Transform)"/>
-        public void Play(Transform followTarget)
+        public virtual void Play(Transform followTarget)
         {
             Stop();
             CurrentPlayer = BroAudio.Play(_sound, followTarget, _overrideGroup);
         }
 
         ///<inheritdoc cref="BroAudio.Play(SoundID, Vector3)"/>
-        public void Play(Vector3 positon)
+        public virtual void Play(Vector3 positon)
         {
             Stop();
             CurrentPlayer = BroAudio.Play(_sound, positon, _overrideGroup);
@@ -87,10 +87,10 @@ namespace Ami.BroAudio
 
         #region Modification
         ///<inheritdoc cref="BroAudio.SetVolume(SoundID,float)"/>
-        public void SetVolume(float vol) => SetVolume(vol, BroAdvice.FadeTime_Immediate);
+        public virtual void SetVolume(float vol) => SetVolume(vol, BroAdvice.FadeTime_Immediate);
 
         ///<inheritdoc cref="BroAudio.SetVolume(SoundID,float,float)"/>
-        public void SetVolume(float vol, float fadeTime)
+        public virtual void SetVolume(float vol, float fadeTime)
         {
             if (IsPlaying)
             {
@@ -98,8 +98,8 @@ namespace Ami.BroAudio
             }
         }
 
-        public void SetPitch(float pitch) => SetPitch(pitch, BroAdvice.FadeTime_Immediate);
-        public void SetPitch(float pitch, float fadeTime)
+        public virtual void SetPitch(float pitch) => SetPitch(pitch, BroAdvice.FadeTime_Immediate);
+        public virtual void SetPitch(float pitch, float fadeTime)
         {
             if (IsPlaying)
             {

--- a/Assets/BroAudio/Runtime/MonoComponent/SoundSource.cs
+++ b/Assets/BroAudio/Runtime/MonoComponent/SoundSource.cs
@@ -14,26 +14,26 @@ namespace Ami.BroAudio
             StayHere,
         }
 
-        [SerializeField] bool _onlyPlayOnce = false;
-        [SerializeField, FormerlySerializedAs("_playOnStart")] bool _playOnEnable = true;
-        [SerializeField] bool _stopOnDisable = false;
-        [SerializeField] float _overrideFadeOut = -1f;
+        [SerializeField] protected bool _onlyPlayOnce = false;
+        [SerializeField, FormerlySerializedAs("_playOnStart")] protected bool _playOnEnable = false;
+        [SerializeField] protected bool _stopOnDisable = false;
+        [SerializeField] protected float _overrideFadeOut = -1f;
         [Space]
-        [SerializeField] SoundID _sound = default;
-        [SerializeField] PlaybackGroup _overrideGroup = null;
-        [SerializeField] PositionMode _positionMode = default;
-        [SerializeField] float _delay = 0f;
+        [SerializeField] protected SoundID _sound = default;
+        [SerializeField] protected PlaybackGroup _overrideGroup = null;
+        [SerializeField] protected PositionMode _positionMode = default;
+        [SerializeField] protected float _delay = 0f;
 
-        public IAudioPlayer CurrentPlayer { get; private set; }
+        public virtual IAudioPlayer CurrentPlayer { get; private set; }
 
         ///<inheritdoc cref="IAudioPlayer.IsPlaying()"/>
-        public bool IsPlaying => CurrentPlayer != null && CurrentPlayer.IsPlaying;
+        public virtual bool IsPlaying => CurrentPlayer != null && CurrentPlayer.IsPlaying;
 
         ///<inheritdoc cref="IAudioPlayer.IsActive()"/>
-        public bool IsActive => CurrentPlayer != null && CurrentPlayer.IsActive;
+        public virtual bool IsActive => CurrentPlayer != null && CurrentPlayer.IsActive;
 
 
-        private void OnEnable()
+        protected virtual void OnEnable()
         {
             if (!_playOnEnable)
             {
@@ -52,7 +52,7 @@ namespace Ami.BroAudio
             }
         }
 
-        private void OnDisable()
+        protected virtual void OnDisable()
         {
             if(_stopOnDisable && CurrentPlayer != null && CurrentPlayer.IsPlaying)
             {

--- a/Assets/BroAudio/TestBootstrapper.cs
+++ b/Assets/BroAudio/TestBootstrapper.cs
@@ -1,0 +1,13 @@
+using Ami.BroAudio;
+using UnityEngine;
+
+public class TestBootstrapper 
+{
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+    public static void Init()
+    {
+        var go = new GameObject("TestBootstrapper");
+        go.AddComponent<SoundSource>();
+
+    }
+}

--- a/Assets/BroAudio/TestBootstrapper.cs.meta
+++ b/Assets/BroAudio/TestBootstrapper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bdc9c640d428d8c4fb838fd09dc8ab7e


### PR DESCRIPTION
# What This PR Does
- Fixes an issue where SoundSource components added via AddComponent (before BroAudio's done initializing) would throw errors.
- Makes SoundSource more subclass‑friendly by exposing key configuration fields and lifecycle methods through protected / protected virtual / public virtual access modifiers.

# Why These Changes Are Needed
Although SoundSource can technically be subclassed, many of its important fields (like _sound) and lifecycle methods are private or non‑virtual. This prevents users from extending the class safely without duplicating internal logic, which leads to brittle code and goes against the DRY principle.

# Use Case
I’m experimenting with a system for persistent audio layers (e.g., Fire Emblem–style crossfades). This requires a SoundSource variant that maintains a single IAudioPlayer instance across its lifetime to ensure consistent volume/pitch adjustments. With the current access modifiers, this behavior can’t be implemented without copying internal BroAudio logic, which risks breaking on future updates.

# Implementation Notes
- No breaking API changes 
- The initialization bug is resolved by defaulting SoundSource's _playOnEnable to false instead of true, preventing premature playback attempts before BroAudio is ready.
- For verification, I added a small TestBootstrapper class that instantiates a SoundSource via AddComponent before scene load.
  - This demonstrates the fix working and confirms that no errors are thrown during early initialization.