### PR TITLE
Use PlayScheduled+handover for sample-accurate loops

### DIFF
--- a/Assets/BroAudio/Runtime/Player/AudioPlayer.Playback.cs
+++ b/Assets/BroAudio/Runtime/Player/AudioPlayer.Playback.cs
@@ -81,7 +81,6 @@ namespace Ami.BroAudio.Runtime
                 yield break;
             }
 
-            // TODO: don't do this every loop?
             SetClipDelayIfNotScheduled();
 #if PACKAGE_ADDRESSABLES
             if (_clip is BroAudioClip broAudioClip && broAudioClip.IsAddressablesAvailable() && !broAudioClip.IsLoaded)

--- a/Assets/BroAudio/Runtime/Player/AudioPlayer.Playback.cs
+++ b/Assets/BroAudio/Runtime/Player/AudioPlayer.Playback.cs
@@ -119,13 +119,12 @@ namespace Ami.BroAudio.Runtime
             {
                 SetTrackEffect(audioTypePref.EffectType, SetEffectMode.Add);
             }
-
-            bool hasLoop = _pref.Entity.HasLoop(out _, out _);
+            
             double dspTime = AudioSettings.dspTime;
             float pitch = AudioSource.pitch;
             double pitchAdjustedDuration = PitchAdjusted(_clip.GetPlayableDuration(), pitch);
             double endDspTime = _pref.ScheduledEndTime <= 0 ? dspTime + pitchAdjustedDuration : _pref.ScheduledEndTime;
-            if (hasLoop && _pref.ScheduledStartTime <= 0)
+            if (_pref.HasLoop() && _pref.ScheduledStartTime <= 0)
             {
                 // TODO: might need a warmup time?
                 _pref.ScheduledStartTime = dspTime;
@@ -173,13 +172,13 @@ namespace Ami.BroAudio.Runtime
                 _clipVolume.Complete(targetClipVolume);
             }
 
-            if (hasLoop || CanLoopIfIsChainedMode())
+            if (_pref.CanHandoverToLoop())
             {
                 if (_pref.IsLoop(LoopType.SeamlessLoop))
                 {
-                    _pref.ScheduledStartTime = 0d;
                     _pref.ApplySeamlessFade();
                 }
+
                 this.RestartCoroutine(ScheduleNextPlayback(endDspTime), ref _handoverScheduleCoroutine);
             }
 
@@ -236,18 +235,13 @@ namespace Ami.BroAudio.Runtime
         
         private IEnumerator ScheduleNextPlayback(double endDspTime, bool isEnd = false)
         {
-            if (!CanHandover(isEnd))
-            {
-                yield break;
-            }
-
             var newPref = _pref;
             if (newPref.IsChainedMode())
             {
                 newPref.ChainedModeStage = isEnd ? PlaybackStage.End : PlaybackStage.Loop;
             }
-            float pitch = AudioSource.pitch;
-            double pitchAdjustedDuration = PitchAdjusted(_clip.GetPlayableDuration(), pitch);
+            
+            double pitchAdjustedDuration = PitchAdjusted(_clip.GetPlayableDuration(), AudioSource.pitch);
             if (_pref.IsLoop(LoopType.SeamlessLoop) && newPref.HasFadeOut(_clip.FadeOut, out float fadeOut, out _))
             {
                 double fadeOutDspTime = endDspTime - fadeOut;
@@ -260,7 +254,7 @@ namespace Ami.BroAudio.Runtime
                 newPref.ScheduledEndTime = endDspTime + pitchAdjustedDuration;
             }
             // TODO: calculate the real warmup time
-            while (AudioSettings.dspTime < endDspTime - 0.1)
+            while (AudioSettings.dspTime < newPref.ScheduledStartTime - 0.1)
             {
                 yield return null;
             }
@@ -290,7 +284,7 @@ namespace Ami.BroAudio.Runtime
             _instanceWrapper = null;
         }
 
-        private bool CanHandover(bool isEnd) =>
+        private bool CanHandover(bool isEnd = false) =>
             isEnd ? _pref.CanHandoverToEnd() : _pref.CanHandoverToLoop();
 
         private static double PitchAdjusted(double duration, float pitch) =>

--- a/Assets/BroAudio/Runtime/Player/AudioPlayer.Playback.cs
+++ b/Assets/BroAudio/Runtime/Player/AudioPlayer.Playback.cs
@@ -29,11 +29,10 @@ namespace Ami.BroAudio.Runtime
         public bool HasStartedPlaying => PlaybackStartingTime > 0;
         private bool IsOnHold => _stopMode == StopMode.Pause && !HasStartedPlaying;
 
-        public void SetPlaybackData(SoundID id, PlaybackPreference pref, IBroAudioClip clip = null)
+        public void SetPlaybackData(SoundID id, PlaybackPreference pref)
         {
             ID = id;
             _pref = pref;
-            _clip = clip;
         }
 
         public void Play()
@@ -74,33 +73,32 @@ namespace Ami.BroAudio.Runtime
                 _audioTypeVolume.Complete(audioTypePref.Volume, false);
             }
             _clipVolume.Complete(0f, false);
-            _clip ??= _pref.PickNewClip(); // TODO: Add change clip for each loop option
+            _clip ??= _pref.PickNewClip();
             if (_clip == null)
             {
                 EndPlaying();
                 yield break;
             }
 
-            // TODO: don't do this every loop?
             SetClipDelayIfNotScheduled();
 #if PACKAGE_ADDRESSABLES
-                if (_clip is BroAudioClip broAudioClip && broAudioClip.IsAddressablesAvailable() && !broAudioClip.IsLoaded)
+            if (_clip is BroAudioClip broAudioClip && broAudioClip.IsAddressablesAvailable() && !broAudioClip.IsLoaded)
+            {
+                if (!SoundManager.Instance.Setting.AutomaticallyLoadAddressableAudioClips)
                 {
-                    if (!SoundManager.Instance.Setting.AutomaticallyLoadAddressableAudioClips)
-                    {
-                        LogNotPreloadedMessage(broAudioClip);
-                    }
-                    yield return WaitForAddressablesToLoad(broAudioClip);
+                    LogNotPreloadedMessage(broAudioClip);
                 }
+                yield return WaitForAddressablesToLoad(broAudioClip);
+            }
 #endif
-            
+
             var audioClip = _clip.GetAudioClip();
             if (!ValidatePlayback(audioClip != null, $"Audio Clip is not assigned in {ID}"))
             {
                 EndPlaying();
                 yield break;
             }
-            
+
             int sampleRate = audioClip.frequency;
             AudioSource.clip = audioClip;
             AudioSource.priority = _pref.Entity.Priority;
@@ -120,12 +118,13 @@ namespace Ami.BroAudio.Runtime
             {
                 SetTrackEffect(audioTypePref.EffectType, SetEffectMode.Add);
             }
-            
+
+            bool hasLoop = _pref.Entity.HasLoop(out _, out _);
             double dspTime = AudioSettings.dspTime;
             double endDspTime = _pref.ScheduledEndTime <= 0 ? dspTime + _clip.GetDuration() : _pref.ScheduledEndTime;
-            if (_pref.Entity.HasLoop(out _, out _) && _pref.ScheduledStartTime <= 0)
+            if (hasLoop && _pref.ScheduledStartTime <= 0)
             {
-                // TODO: might need a warmup time? 
+                // TODO: might need a warmup time?
                 _pref.ScheduledStartTime = dspTime;
                 _pref.ScheduledEndTime = endDspTime;
             }
@@ -171,17 +170,16 @@ namespace Ami.BroAudio.Runtime
                 _clipVolume.Complete(targetClipVolume);
             }
 
-            if (_pref.Entity.HasLoop(out _, out _) || CanLoopIfIsChainedMode())
+            if (hasLoop || CanLoopIfIsChainedMode())
             {
                 if (_pref.IsLoop(LoopType.SeamlessLoop))
                 {
-                    _pref.ScheduledStartTime = 0d; // TODO: why
+                    _pref.ScheduledStartTime = 0d;
                     _pref.ApplySeamlessFade();
                 }
                 this.RestartCoroutine(ScheduleNextPlayback(endDspTime), ref _nextPlaybackSchedulingCoroutine);
             }
-            
-            // TODO: wtf is this?
+
             if (_pref.HasFadeOut(_clip.FadeOut, out float fadeOut, out var fadeOutEase))
             {
                 double fadeOutDSPTime = endDspTime - fadeOut;
@@ -205,8 +203,6 @@ namespace Ami.BroAudio.Runtime
                 TriggerPlaybackHandover();
             }
             EndPlaying();
-            
-            int GetSample(float time) => Utility.GetSample(sampleRate, time);
         }
 
         private void StartPlaying()
@@ -237,7 +233,7 @@ namespace Ami.BroAudio.Runtime
         
         private IEnumerator ScheduleNextPlayback(double endDspTime, bool isEnd = false)
         {
-            if ((isEnd && !_pref.CanHandoverToEnd()) || (!isEnd && !_pref.CanHandoverToLoop()))
+            if (!CanHandover(isEnd))
             {
                 yield break;
             }
@@ -258,9 +254,8 @@ namespace Ami.BroAudio.Runtime
             {
                 ID = ID,
                 Pref = newPref,
-                Clip = _clip, 
                 PreviousTrackEffect = CurrentActiveTrackEffects,
-                TrackVolume = _trackVolume.Target, 
+                TrackVolume = _trackVolume.Target,
                 Pitch = StaticPitch,
             };
             _nextPlayer = OnScheduleNextPlayback?.Invoke(data);
@@ -269,24 +264,21 @@ namespace Ami.BroAudio.Runtime
 
         private void TriggerPlaybackHandover(bool isEnd = false)
         {
-            if ((isEnd && !_pref.CanHandoverToEnd()) || (!isEnd && !_pref.CanHandoverToLoop()))
+            if (!CanHandover(isEnd))
             {
                 return;
             }
 
-            var newPref = _pref;
-            if (newPref.IsChainedMode())
-            {
-                newPref.ChainedModeStage = isEnd ? PlaybackStage.End : PlaybackStage.Loop;
-            }
-
-            ClearScheduleEndEvents(); // it should be rescheduled in the new player
+            ClearScheduleEndEvents();
             _instanceWrapper.UpdateInstance(_nextPlayer);
             _nextPlayer.SetInstanceWrapper(_instanceWrapper);
-            _instanceWrapper = null; // the instance has been transferred to the new player
+            _instanceWrapper = null;
         }
 
-        public void ReceiveHandover(PlaybackHandoverData data)
+        private bool CanHandover(bool isEnd) =>
+            isEnd ? _pref.CanHandoverToEnd() : _pref.CanHandoverToLoop();
+
+        internal void ReceiveHandover(PlaybackHandoverData data)
         {
             SetPlaybackData(data.ID, data.Pref);
             SetVolumeInternal(_trackVolume, data.TrackVolume, 0f);
@@ -441,7 +433,7 @@ namespace Ami.BroAudio.Runtime
 
         private bool CanLoopIfIsChainedMode()
         {
-            return !_pref.IsChainedMode() || (_pref.IsChainedMode() && _pref.ChainedModeStage == PlaybackStage.Loop);
+            return !_pref.IsChainedMode() || _pref.ChainedModeStage == PlaybackStage.Loop;
         }
 
         public IAudioPlayer OnEnd(Action<SoundID> onEnd)

--- a/Assets/BroAudio/Runtime/Player/AudioPlayer.Playback.cs
+++ b/Assets/BroAudio/Runtime/Player/AudioPlayer.Playback.cs
@@ -10,13 +10,15 @@ namespace Ami.BroAudio.Runtime
     [RequireComponent(typeof(AudioSource))]
     public partial class AudioPlayer : MonoBehaviour, IAudioPlayer, IPlayable, IRecyclable<AudioPlayer>
     {
-        public delegate void PlaybackHandover(SoundID id, InstanceWrapper<AudioPlayer> wrapper, PlaybackPreference pref, EffectType effectType, float trackVolume, float pitch);
+        public delegate AudioPlayer NextPlaybackSchedule(PlaybackHandoverData data);
 
-        public PlaybackHandover OnPlaybackHandover;
+        public NextPlaybackSchedule OnScheduleNextPlayback;
 
         private PlaybackPreference _pref;
         private StopMode _stopMode;
         private Coroutine _playbackControlCoroutine = null;
+        private Coroutine _nextPlaybackSchedulingCoroutine = null;
+        private AudioPlayer _nextPlayer;
 
         private event Action<SoundID> _onEnd = null;
         private event Action<IAudioPlayer> _onUpdate = null;
@@ -27,10 +29,11 @@ namespace Ami.BroAudio.Runtime
         public bool HasStartedPlaying => PlaybackStartingTime > 0;
         private bool IsOnHold => _stopMode == StopMode.Pause && !HasStartedPlaying;
 
-        public void SetPlaybackData(SoundID id, PlaybackPreference pref)
+        public void SetPlaybackData(SoundID id, PlaybackPreference pref, IBroAudioClip clip = null)
         {
             ID = id;
             _pref = pref;
+            _clip = clip;
         }
 
         public void Play()
@@ -71,18 +74,15 @@ namespace Ami.BroAudio.Runtime
                 _audioTypeVolume.Complete(audioTypePref.Volume, false);
             }
             _clipVolume.Complete(0f, false);
-            int sampleRate = _clip != null ? _clip.GetAudioClip().frequency : 0;
-            bool hasScheduledPlay = false;
-            if (!HasStartedPlaying) // we only do the following process when it's fresh
+            _clip ??= _pref.PickNewClip(); // TODO: Add change clip for each loop option
+            if (_clip == null)
             {
-                _clip = _pref.PickNewClip();
-                if (_clip == null)
-                {
-                    EndPlaying();
-                    yield break;
-                }
+                EndPlaying();
+                yield break;
+            }
 
-                SetClipDelayIfNotScheduled();
+            // TODO: don't do this every loop?
+            SetClipDelayIfNotScheduled();
 #if PACKAGE_ADDRESSABLES
                 if (_clip is BroAudioClip broAudioClip && broAudioClip.IsAddressablesAvailable() && !broAudioClip.IsLoaded)
                 {
@@ -93,119 +93,123 @@ namespace Ami.BroAudio.Runtime
                     yield return WaitForAddressablesToLoad(broAudioClip);
                 }
 #endif
-
-                var audioClip = _clip.GetAudioClip();
-                sampleRate = audioClip.frequency;
+            
+            var audioClip = _clip.GetAudioClip();
             if (!ValidatePlayback(audioClip != null, $"Audio Clip is not assigned in {ID}"))
             {
                 EndPlaying();
                 yield break;
             }
-                AudioSource.clip = audioClip;
-                AudioSource.priority = _pref.Entity.Priority;
+            
+            int sampleRate = audioClip.frequency;
+            AudioSource.clip = audioClip;
+            AudioSource.priority = _pref.Entity.Priority;
 
-                SetPlayPosition(sampleRate);
-                SetInitialPitch(_pref.Entity, audioTypePref);
-                SetSpatial(_pref);
+            SetPlayPosition(sampleRate);
+            SetInitialPitch(_pref.Entity, audioTypePref);
+            SetSpatial(_pref);
 #if !UNITY_WEBGL
-                AudioTrack = MixerPool.GetTrack(TrackType);
+            AudioTrack = MixerPool.GetTrack(TrackType);
 #endif
 
-                if (IsDominator)
-                {
-                    TrackType = AudioTrackType.Dominator;
-                }
-                else
-                {
-                    SetTrackEffect(audioTypePref.EffectType, SetEffectMode.Add);
-                }
-
-                SchedulePlayback(out hasScheduledPlay);
-                if (hasScheduledPlay)
-                {
-                    yield return WaitForScheduledStartTime();
-                }
-
-                if (_decorators.TryGetDecorator<MusicPlayer>(out var musicPlayer))
-                {
-                    AudioSource.reverbZoneMix = 0f;
-                    AudioSource.priority = AudioConstant.HighestPriority;
-                    musicPlayer.DoTransition(ref _pref);
-                    while (musicPlayer.IsWaitingForTransition)
-                    {
-                        yield return null;
-                    }
-                }
+            if (IsDominator)
+            {
+                TrackType = AudioTrackType.Dominator;
+            }
+            else
+            {
+                SetTrackEffect(audioTypePref.EffectType, SetEffectMode.Add);
+            }
+            
+            double dspTime = AudioSettings.dspTime;
+            double endDspTime = _pref.ScheduledEndTime <= 0 ? dspTime + _clip.GetDuration() : _pref.ScheduledEndTime;
+            if (_pref.Entity.HasLoop(out _, out _) && _pref.ScheduledStartTime <= 0)
+            {
+                // TODO: might need a warmup time? 
+                _pref.ScheduledStartTime = dspTime;
+                _pref.ScheduledEndTime = endDspTime;
             }
 
-            do
+            SchedulePlayback();
+            if (_timeBeforeStartSchedule > 0)
             {
-                if (!hasScheduledPlay)
+                yield return WaitForScheduledStartTime();
+            }
+
+            if (_decorators.TryGetDecorator<MusicPlayer>(out var musicPlayer))
+            {
+                AudioSource.reverbZoneMix = 0f;
+                AudioSource.priority = AudioConstant.HighestPriority;
+                musicPlayer.DoTransition(ref _pref);
+                while (musicPlayer.IsWaitingForTransition)
                 {
-                    StartPlaying(sampleRate);
+                    yield return null;
                 }
+            }
+            
+            if (_pref.ScheduledStartTime <= 0)
+            {
+                StartPlaying();
+            }
 
-                if (!HasStartedPlaying)
-                {
-                    PlaybackStartingTime = TimeExtension.UnscaledCurrentFrameBeganTime;
-                    _onStart?.Invoke(this);
-                    _onStart = null;
-                    _onUpdate?.Invoke(this);
-                    hasScheduledPlay = false;
-                }
+            if (!HasStartedPlaying)
+            {
+                PlaybackStartingTime = TimeExtension.UnscaledCurrentFrameBeganTime;
+                _onStart?.Invoke(this);
+                _onStart = null;
+                _onUpdate?.Invoke(this);
+            }
 
-                float targetClipVolume = _clip.Volume * _pref.Entity.GetMasterVolume();
-
-                #region FadeIn
-                if (_pref.HasFadeIn(_clip.FadeIn, out var fadeIn, out var fadeInEase))
-                {
-                    _clipVolume.SetTarget(targetClipVolume);
+            float targetClipVolume = _clip.Volume * _pref.Entity.GetMasterVolume();
+            if (_pref.HasFadeIn(_clip.FadeIn, out var fadeIn, out var fadeInEase))
+            {
+                _clipVolume.SetTarget(targetClipVolume);
                 yield return Fade(_clipVolume, fadeIn, fadeInEase, _onUpdate);
-                }
-                else
-                {
-                    _clipVolume.Complete(targetClipVolume);
-                }
-                #endregion
+            }
+            else
+            {
+                _clipVolume.Complete(targetClipVolume);
+            }
 
+            if (_pref.Entity.HasLoop(out _, out _) || CanLoopIfIsChainedMode())
+            {
                 if (_pref.IsLoop(LoopType.SeamlessLoop))
                 {
-                    _pref.ScheduledStartTime = 0d;
+                    _pref.ScheduledStartTime = 0d; // TODO: why
                     _pref.ApplySeamlessFade();
                 }
-
-                #region FadeOut
-                int endSample = AudioSource.clip.samples - GetSample(sampleRate, _clip.EndPosition);
+                this.RestartCoroutine(ScheduleNextPlayback(endDspTime), ref _nextPlaybackSchedulingCoroutine);
+            }
             
-                if (_pref.HasFadeOut(_clip.FadeOut, out float fadeOut, out var fadeOutEase))
+            // TODO: wtf is this?
+            if (_pref.HasFadeOut(_clip.FadeOut, out float fadeOut, out var fadeOutEase))
+            {
+                double fadeOutDSPTime = endDspTime - fadeOut;
+                while (AudioSettings.dspTime < fadeOutDSPTime)
                 {
-                    while (endSample - AudioSource.timeSamples > fadeOut * sampleRate)
-                    {
-                        yield return null;
+                    yield return null;
                     _onUpdate?.Invoke(this);
-                    }
+                }
 
-                    TriggerPlaybackHandover();
-                    _clipVolume.SetTarget(0f);
+                TriggerPlaybackHandover();
+                _clipVolume.SetTarget(0f);
                 yield return Fade(_clipVolume, fadeOut, fadeOutEase, _onUpdate);
-                }
-                else
+            }
+            else
+            {
+                while (AudioSettings.dspTime < endDspTime)
                 {
-                    bool hasPlayed = false;
-                    while (!HasEndPlaying(ref hasPlayed, endSample, sampleRate))
-                    {
-                        yield return null;
+                    yield return null;
                     _onUpdate?.Invoke(this);
-                    }
-                    TriggerPlaybackHandover();
                 }
-                #endregion
-            } while (_pref.IsLoop(LoopType.Loop) && CanLoopIfIsChainedMode());
-
+                TriggerPlaybackHandover();
+            }
             EndPlaying();
+            
+            int GetSample(float time) => Utility.GetSample(sampleRate, time);
         }
 
-        private void StartPlaying(int sampleRate)
+        private void StartPlaying()
         {
             switch (_stopMode)
             {
@@ -217,7 +221,7 @@ namespace Ami.BroAudio.Runtime
                 case StopMode.Stop:
                 case StopMode.Pause:
                 case StopMode.Mute:
-                    PlayFromPos(sampleRate);
+                    AudioSource.Play();
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -225,29 +229,42 @@ namespace Ami.BroAudio.Runtime
             _stopMode = default;
         }
 
-        private void PlayFromPos(int sampleRate)
-        {
-            SetPlayPosition(sampleRate);
-            AudioSource.Play();
-        }
-
         private void SetPlayPosition(int sampleRate)
         {
             AudioSource.Stop();
             AudioSource.timeSamples = GetSample(sampleRate, _clip.StartPosition);
         }
-
-        // more accurate than AudioSource.isPlaying
-        private bool HasEndPlaying(ref bool hasPlayed, int endSample, int sampleRate)
+        
+        private IEnumerator ScheduleNextPlayback(double endDspTime, bool isEnd = false)
         {
-            int currentSample = AudioSource.timeSamples;
-            int startSample = GetSample(sampleRate, _clip.StartPosition);
-            if (!hasPlayed)
+            if ((isEnd && !_pref.CanHandoverToEnd()) || (!isEnd && !_pref.CanHandoverToLoop()))
             {
-                hasPlayed = currentSample > startSample;
+                yield break;
             }
 
-            return hasPlayed && (currentSample <= startSample || currentSample >= endSample);
+            var newPref = _pref;
+            if (newPref.IsChainedMode())
+            {
+                newPref.ChainedModeStage = isEnd ? PlaybackStage.End : PlaybackStage.Loop;
+            }
+            newPref.ScheduledStartTime = endDspTime;
+            newPref.ScheduledEndTime = endDspTime + _clip.GetDuration();
+            // TODO: calculate the real warmup time
+            while (AudioSettings.dspTime < endDspTime - 0.1)
+            {
+                yield return null;
+            }
+            var data = new PlaybackHandoverData()
+            {
+                ID = ID,
+                Pref = newPref,
+                Clip = _clip, 
+                PreviousTrackEffect = CurrentActiveTrackEffects,
+                TrackVolume = _trackVolume.Target, 
+                Pitch = StaticPitch,
+            };
+            _nextPlayer = OnScheduleNextPlayback?.Invoke(data);
+            OnScheduleNextPlayback = null;
         }
 
         private void TriggerPlaybackHandover(bool isEnd = false)
@@ -264,9 +281,20 @@ namespace Ami.BroAudio.Runtime
             }
 
             ClearScheduleEndEvents(); // it should be rescheduled in the new player
-            OnPlaybackHandover?.Invoke(ID, _instanceWrapper, newPref, CurrentActiveTrackEffects, _trackVolume.Target, StaticPitch);
-            OnPlaybackHandover = null;
+            _instanceWrapper.UpdateInstance(_nextPlayer);
+            _nextPlayer.SetInstanceWrapper(_instanceWrapper);
             _instanceWrapper = null; // the instance has been transferred to the new player
+        }
+
+        public void ReceiveHandover(PlaybackHandoverData data)
+        {
+            SetPlaybackData(data.ID, data.Pref);
+            SetVolumeInternal(_trackVolume, data.TrackVolume, 0f);
+            this.SetPitch(data.Pitch);
+            PlayInternal();
+#if !UNITY_WEBGL
+            SetTrackEffect(data.PreviousTrackEffect, SetEffectMode.Override);
+#endif
         }
 
         private static bool ValidatePlayback(bool condition, string message, UnityEngine.Object context = null)
@@ -401,8 +429,7 @@ namespace Ami.BroAudio.Runtime
             _clip = null;
             ResetSpatial();
             ResetEffect();
-
-            // Don't add StopCoroutine(_playbackCoroutine) here, as this method is typically called within it, and further processing after this method cannot be guaranteed.
+            
             _trackVolume.StopCoroutine();
             _audioTypeVolume.StopCoroutine();
 

--- a/Assets/BroAudio/Runtime/Player/AudioPlayer.Playback.cs
+++ b/Assets/BroAudio/Runtime/Player/AudioPlayer.Playback.cs
@@ -29,10 +29,11 @@ namespace Ami.BroAudio.Runtime
         public bool HasStartedPlaying => PlaybackStartingTime > 0;
         private bool IsOnHold => _stopMode == StopMode.Pause && !HasStartedPlaying;
 
-        public void SetPlaybackData(SoundID id, PlaybackPreference pref)
+        public void SetPlaybackData(SoundID id, PlaybackPreference pref, IBroAudioClip clip = null)
         {
             ID = id;
             _pref = pref;
+            _clip = clip;
         }
 
         public void Play()
@@ -73,13 +74,14 @@ namespace Ami.BroAudio.Runtime
                 _audioTypeVolume.Complete(audioTypePref.Volume, false);
             }
             _clipVolume.Complete(0f, false);
-            _clip ??= _pref.PickNewClip();
+            _clip ??= _pref.PickNewClip(); // TODO: Add change clip for each loop option
             if (_clip == null)
             {
                 EndPlaying();
                 yield break;
             }
 
+            // TODO: don't do this every loop?
             SetClipDelayIfNotScheduled();
 #if PACKAGE_ADDRESSABLES
             if (_clip is BroAudioClip broAudioClip && broAudioClip.IsAddressablesAvailable() && !broAudioClip.IsLoaded)
@@ -121,7 +123,9 @@ namespace Ami.BroAudio.Runtime
 
             bool hasLoop = _pref.Entity.HasLoop(out _, out _);
             double dspTime = AudioSettings.dspTime;
-            double endDspTime = _pref.ScheduledEndTime <= 0 ? dspTime + _clip.GetDuration() : _pref.ScheduledEndTime;
+            float pitch = AudioSource.pitch;
+            double pitchAdjustedDuration = Mathf.Approximately(pitch, 0f) ? _clip.GetDuration() : _clip.GetDuration() / pitch;
+            double endDspTime = _pref.ScheduledEndTime <= 0 ? dspTime + pitchAdjustedDuration : _pref.ScheduledEndTime;
             if (hasLoop && _pref.ScheduledStartTime <= 0)
             {
                 // TODO: might need a warmup time?
@@ -244,7 +248,9 @@ namespace Ami.BroAudio.Runtime
                 newPref.ChainedModeStage = isEnd ? PlaybackStage.End : PlaybackStage.Loop;
             }
             newPref.ScheduledStartTime = endDspTime;
-            newPref.ScheduledEndTime = endDspTime + _clip.GetDuration();
+            float nextPitch = AudioSource.pitch;
+            double nextPitchAdjustedDuration = Mathf.Approximately(nextPitch, 0f) ? _clip.GetDuration() : _clip.GetDuration() / nextPitch;
+            newPref.ScheduledEndTime = endDspTime + nextPitchAdjustedDuration;
             // TODO: calculate the real warmup time
             while (AudioSettings.dspTime < endDspTime - 0.1)
             {
@@ -254,6 +260,7 @@ namespace Ami.BroAudio.Runtime
             {
                 ID = ID,
                 Pref = newPref,
+                Clip = newPref.IsChainedMode() ? null : _clip,
                 PreviousTrackEffect = CurrentActiveTrackEffects,
                 TrackVolume = _trackVolume.Target,
                 Pitch = StaticPitch,
@@ -280,7 +287,7 @@ namespace Ami.BroAudio.Runtime
 
         internal void ReceiveHandover(PlaybackHandoverData data)
         {
-            SetPlaybackData(data.ID, data.Pref);
+            SetPlaybackData(data.ID, data.Pref, data.Clip);
             SetVolumeInternal(_trackVolume, data.TrackVolume, 0f);
             this.SetPitch(data.Pitch);
             PlayInternal();

--- a/Assets/BroAudio/Runtime/Player/AudioPlayer.Playback.cs
+++ b/Assets/BroAudio/Runtime/Player/AudioPlayer.Playback.cs
@@ -10,14 +10,14 @@ namespace Ami.BroAudio.Runtime
     [RequireComponent(typeof(AudioSource))]
     public partial class AudioPlayer : MonoBehaviour, IAudioPlayer, IPlayable, IRecyclable<AudioPlayer>
     {
-        public delegate AudioPlayer NextPlaybackSchedule(PlaybackHandoverData data);
+        public delegate AudioPlayer HandoverPlayerFactory(PlaybackHandoverData handover);
 
-        public NextPlaybackSchedule OnScheduleNextPlayback;
+        public HandoverPlayerFactory RequestNextPlayer;
 
         private PlaybackPreference _pref;
         private StopMode _stopMode;
         private Coroutine _playbackControlCoroutine = null;
-        private Coroutine _nextPlaybackSchedulingCoroutine = null;
+        private Coroutine _handoverScheduleCoroutine = null;
         private AudioPlayer _nextPlayer;
 
         private event Action<SoundID> _onEnd = null;
@@ -124,7 +124,7 @@ namespace Ami.BroAudio.Runtime
             bool hasLoop = _pref.Entity.HasLoop(out _, out _);
             double dspTime = AudioSettings.dspTime;
             float pitch = AudioSource.pitch;
-            double pitchAdjustedDuration = Mathf.Approximately(pitch, 0f) ? _clip.GetDuration() : _clip.GetDuration() / pitch;
+            double pitchAdjustedDuration = PitchAdjusted(_clip.GetPlayableDuration(), pitch);
             double endDspTime = _pref.ScheduledEndTime <= 0 ? dspTime + pitchAdjustedDuration : _pref.ScheduledEndTime;
             if (hasLoop && _pref.ScheduledStartTime <= 0)
             {
@@ -134,7 +134,7 @@ namespace Ami.BroAudio.Runtime
             }
 
             SchedulePlayback();
-            if (_timeBeforeStartSchedule > 0)
+            if (_secondsUntilScheduledStart > 0)
             {
                 yield return WaitForScheduledStartTime();
             }
@@ -181,19 +181,19 @@ namespace Ami.BroAudio.Runtime
                     _pref.ScheduledStartTime = 0d;
                     _pref.ApplySeamlessFade();
                 }
-                this.RestartCoroutine(ScheduleNextPlayback(endDspTime), ref _nextPlaybackSchedulingCoroutine);
+                this.RestartCoroutine(ScheduleNextPlayback(endDspTime), ref _handoverScheduleCoroutine);
             }
 
             if (_pref.HasFadeOut(_clip.FadeOut, out float fadeOut, out var fadeOutEase))
             {
-                double fadeOutDSPTime = endDspTime - fadeOut;
-                while (AudioSettings.dspTime < fadeOutDSPTime)
+                double fadeOutDspTime = endDspTime - fadeOut;
+                while (AudioSettings.dspTime < fadeOutDspTime)
                 {
                     yield return null;
                     _onUpdate?.Invoke(this);
                 }
 
-                TriggerPlaybackHandover();
+                BeginHandover();
                 _clipVolume.SetTarget(0f);
                 yield return Fade(_clipVolume, fadeOut, fadeOutEase, _onUpdate);
             }
@@ -204,7 +204,7 @@ namespace Ami.BroAudio.Runtime
                     yield return null;
                     _onUpdate?.Invoke(this);
                 }
-                TriggerPlaybackHandover();
+                BeginHandover();
             }
             EndPlaying();
         }
@@ -248,28 +248,28 @@ namespace Ami.BroAudio.Runtime
                 newPref.ChainedModeStage = isEnd ? PlaybackStage.End : PlaybackStage.Loop;
             }
             newPref.ScheduledStartTime = endDspTime;
-            float nextPitch = AudioSource.pitch;
-            double nextPitchAdjustedDuration = Mathf.Approximately(nextPitch, 0f) ? _clip.GetDuration() : _clip.GetDuration() / nextPitch;
-            newPref.ScheduledEndTime = endDspTime + nextPitchAdjustedDuration;
+            float pitch = AudioSource.pitch;
+            double pitchAdjustedDuration = PitchAdjusted(_clip.GetPlayableDuration(), pitch);
+            newPref.ScheduledEndTime = endDspTime + pitchAdjustedDuration;
             // TODO: calculate the real warmup time
             while (AudioSettings.dspTime < endDspTime - 0.1)
             {
                 yield return null;
             }
-            var data = new PlaybackHandoverData()
+            var handover = new PlaybackHandoverData()
             {
                 ID = ID,
                 Pref = newPref,
                 Clip = newPref.IsChainedMode() ? null : _clip,
-                PreviousTrackEffect = CurrentActiveTrackEffects,
+                TrackEffect = CurrentActiveTrackEffects,
                 TrackVolume = _trackVolume.Target,
                 Pitch = StaticPitch,
             };
-            _nextPlayer = OnScheduleNextPlayback?.Invoke(data);
-            OnScheduleNextPlayback = null;
+            _nextPlayer = RequestNextPlayer?.Invoke(handover);
+            RequestNextPlayer = null;
         }
 
-        private void TriggerPlaybackHandover(bool isEnd = false)
+        private void BeginHandover(bool isEnd = false)
         {
             if (!CanHandover(isEnd))
             {
@@ -285,14 +285,17 @@ namespace Ami.BroAudio.Runtime
         private bool CanHandover(bool isEnd) =>
             isEnd ? _pref.CanHandoverToEnd() : _pref.CanHandoverToLoop();
 
-        internal void ReceiveHandover(PlaybackHandoverData data)
+        private static double PitchAdjusted(double duration, float pitch) =>
+            Mathf.Approximately(pitch, 0f) ? duration : duration / pitch;
+
+        internal void ReceiveHandover(PlaybackHandoverData handover)
         {
-            SetPlaybackData(data.ID, data.Pref, data.Clip);
-            SetVolumeInternal(_trackVolume, data.TrackVolume, 0f);
-            this.SetPitch(data.Pitch);
+            SetPlaybackData(handover.ID, handover.Pref, handover.Clip);
+            SetVolumeInternal(_trackVolume, handover.TrackVolume, 0f);
+            this.SetPitch(handover.Pitch);
             PlayInternal();
 #if !UNITY_WEBGL
-            SetTrackEffect(data.PreviousTrackEffect, SetEffectMode.Override);
+            SetTrackEffect(handover.TrackEffect, SetEffectMode.Override);
 #endif
         }
 
@@ -366,7 +369,7 @@ namespace Ami.BroAudio.Runtime
             IsStopping = true;
             _pref.SetNextFadeOut(overrideFade);
 
-            TriggerPlaybackHandover(isEnd: true);
+            BeginHandover(isEnd: true);
             #region FadeOut
             if (_pref.HasFadeOut(_clip.FadeOut, out float fadeOut, out var fadeOutEase))
             {

--- a/Assets/BroAudio/Runtime/Player/AudioPlayer.Playback.cs
+++ b/Assets/BroAudio/Runtime/Player/AudioPlayer.Playback.cs
@@ -246,10 +246,19 @@ namespace Ami.BroAudio.Runtime
             {
                 newPref.ChainedModeStage = isEnd ? PlaybackStage.End : PlaybackStage.Loop;
             }
-            newPref.ScheduledStartTime = endDspTime;
             float pitch = AudioSource.pitch;
             double pitchAdjustedDuration = PitchAdjusted(_clip.GetPlayableDuration(), pitch);
-            newPref.ScheduledEndTime = endDspTime + pitchAdjustedDuration;
+            if (_pref.IsLoop(LoopType.SeamlessLoop) && newPref.HasFadeOut(_clip.FadeOut, out float fadeOut, out _))
+            {
+                double fadeOutDspTime = endDspTime - fadeOut;
+                newPref.ScheduledStartTime = fadeOutDspTime;
+                newPref.ScheduledEndTime = fadeOutDspTime + pitchAdjustedDuration;
+            }
+            else
+            {
+                newPref.ScheduledStartTime = endDspTime;
+                newPref.ScheduledEndTime = endDspTime + pitchAdjustedDuration;
+            }
             // TODO: calculate the real warmup time
             while (AudioSettings.dspTime < endDspTime - 0.1)
             {
@@ -259,7 +268,7 @@ namespace Ami.BroAudio.Runtime
             {
                 ID = ID,
                 Pref = newPref,
-                Clip = newPref.IsChainedMode() ? null : _clip,
+                Clip = (newPref.IsChainedMode() && newPref.ChainedModeStage != PlaybackStage.Loop) ? null : _clip,
                 TrackEffect = CurrentActiveTrackEffects,
                 TrackVolume = _trackVolume.Target,
                 Pitch = StaticPitch,

--- a/Assets/BroAudio/Runtime/Player/AudioPlayer.Playback.cs
+++ b/Assets/BroAudio/Runtime/Player/AudioPlayer.Playback.cs
@@ -172,7 +172,7 @@ namespace Ami.BroAudio.Runtime
                 _clipVolume.Complete(targetClipVolume);
             }
 
-            if (_pref.CanHandoverToLoop())
+            if (_pref.HasLoop() && _pref.ChainedModeStage != PlaybackStage.End)
             {
                 if (_pref.IsLoop(LoopType.SeamlessLoop))
                 {
@@ -241,8 +241,9 @@ namespace Ami.BroAudio.Runtime
                 newPref.ChainedModeStage = isEnd ? PlaybackStage.End : PlaybackStage.Loop;
             }
             
+            // TODO: it should be set in the new player, as it might pick a new clip!
             double pitchAdjustedDuration = PitchAdjusted(_clip.GetPlayableDuration(), AudioSource.pitch);
-            if (_pref.IsLoop(LoopType.SeamlessLoop) && newPref.HasFadeOut(_clip.FadeOut, out float fadeOut, out _))
+            if (!isEnd && _pref.IsLoop(LoopType.SeamlessLoop) && newPref.HasFadeOut(_clip.FadeOut, out float fadeOut, out _))
             {
                 double fadeOutDspTime = endDspTime - fadeOut;
                 newPref.ScheduledStartTime = fadeOutDspTime;
@@ -254,19 +255,23 @@ namespace Ami.BroAudio.Runtime
                 newPref.ScheduledEndTime = endDspTime + pitchAdjustedDuration;
             }
             // TODO: calculate the real warmup time
-            while (AudioSettings.dspTime < newPref.ScheduledStartTime - 0.1)
+            var warmUpTime = isEnd ? 0 : 0.1;
+            while (AudioSettings.dspTime < newPref.ScheduledStartTime - warmUpTime)
             {
                 yield return null;
             }
+
+            bool needNewClip = _pref.IsChainedMode() && (isEnd || _pref.ChainedModeStage == PlaybackStage.Start);
             var handover = new PlaybackHandoverData()
             {
                 ID = ID,
                 Pref = newPref,
-                Clip = (newPref.IsChainedMode() && newPref.ChainedModeStage != PlaybackStage.Loop) ? null : _clip,
+                Clip = needNewClip ? null : _clip,
                 TrackEffect = CurrentActiveTrackEffects,
                 TrackVolume = _trackVolume.Target,
                 Pitch = StaticPitch,
             };
+            
             _nextPlayer = RequestNextPlayer?.Invoke(handover);
             RequestNextPlayer = null;
         }
@@ -371,7 +376,12 @@ namespace Ami.BroAudio.Runtime
             IsStopping = true;
             _pref.SetNextFadeOut(overrideFade);
 
-            BeginHandover(isEnd: true);
+            if (_pref.CanHandoverToEnd())
+            {
+                this.RestartCoroutine(ScheduleNextPlayback(AudioSettings.dspTime, isEnd: true), ref _handoverScheduleCoroutine);  // Start the next playback immediately
+                BeginHandover(isEnd: true);
+            }
+
             #region FadeOut
             if (_pref.HasFadeOut(_clip.FadeOut, out float fadeOut, out var fadeOutEase))
             {

--- a/Assets/BroAudio/Runtime/Player/AudioPlayer.Playback.cs
+++ b/Assets/BroAudio/Runtime/Player/AudioPlayer.Playback.cs
@@ -123,11 +123,16 @@ namespace Ami.BroAudio.Runtime
             double dspTime = AudioSettings.dspTime;
             float pitch = AudioSource.pitch;
             double pitchAdjustedDuration = PitchAdjusted(_clip.GetPlayableDuration(), pitch);
-            double endDspTime = _pref.ScheduledEndTime <= 0 ? dspTime + pitchAdjustedDuration : _pref.ScheduledEndTime;
+            double startBaseTime = _pref.ScheduledStartTime > 0 ? _pref.ScheduledStartTime : dspTime;
+            double endDspTime = _pref.ScheduledEndTime <= 0 ? startBaseTime + pitchAdjustedDuration : _pref.ScheduledEndTime;
             if (_pref.HasLoop() && _pref.ScheduledStartTime <= 0)
             {
                 // TODO: might need a warmup time?
                 _pref.ScheduledStartTime = dspTime;
+                _pref.ScheduledEndTime = endDspTime;
+            }
+            else if (_pref.ScheduledStartTime > 0 && _pref.ScheduledEndTime <= 0)
+            {
                 _pref.ScheduledEndTime = endDspTime;
             }
 
@@ -241,18 +246,25 @@ namespace Ami.BroAudio.Runtime
                 newPref.ChainedModeStage = isEnd ? PlaybackStage.End : PlaybackStage.Loop;
             }
             
-            // TODO: it should be set in the new player, as it might pick a new clip!
-            double pitchAdjustedDuration = PitchAdjusted(_clip.GetPlayableDuration(), AudioSource.pitch);
+            bool needNewClip = _pref.IsChainedMode() && (isEnd || _pref.ChainedModeStage == PlaybackStage.Start);
+            // Reset so the new player can recalculate against its picked clip's duration.
+            newPref.ScheduledEndTime = 0;
             if (!isEnd && _pref.IsLoop(LoopType.SeamlessLoop) && newPref.HasFadeOut(_clip.FadeOut, out float fadeOut, out _))
             {
                 double fadeOutDspTime = endDspTime - fadeOut;
                 newPref.ScheduledStartTime = fadeOutDspTime;
-                newPref.ScheduledEndTime = fadeOutDspTime + pitchAdjustedDuration;
+                if (!needNewClip)
+                {
+                    newPref.ScheduledEndTime = fadeOutDspTime + PitchAdjusted(_clip.GetPlayableDuration(), AudioSource.pitch);
+                }
             }
             else
             {
                 newPref.ScheduledStartTime = endDspTime;
-                newPref.ScheduledEndTime = endDspTime + pitchAdjustedDuration;
+                if (!needNewClip)
+                {
+                    newPref.ScheduledEndTime = endDspTime + PitchAdjusted(_clip.GetPlayableDuration(), AudioSource.pitch);
+                }
             }
             // TODO: calculate the real warmup time
             var warmUpTime = isEnd ? 0 : 0.1;
@@ -261,7 +273,6 @@ namespace Ami.BroAudio.Runtime
                 yield return null;
             }
 
-            bool needNewClip = _pref.IsChainedMode() && (isEnd || _pref.ChainedModeStage == PlaybackStage.Start);
             var handover = new PlaybackHandoverData()
             {
                 ID = ID,

--- a/Assets/BroAudio/Runtime/Player/AudioPlayer.Recycling.cs
+++ b/Assets/BroAudio/Runtime/Player/AudioPlayer.Recycling.cs
@@ -25,9 +25,9 @@ namespace Ami.BroAudio.Runtime
             DestroyAddedEffectComponents();
             ClearEvents();
             this.SafeStopCoroutine(_playbackControlCoroutine);
-            this.SafeStopCoroutine(_nextPlaybackSchedulingCoroutine);
+            this.SafeStopCoroutine(_handoverScheduleCoroutine);
             _playbackControlCoroutine = null;
-            _nextPlaybackSchedulingCoroutine = null;
+            _handoverScheduleCoroutine = null;
             _nextPlayer = null;
 
             if (TryGetMixerAndTrack(out _, out var track))
@@ -49,7 +49,7 @@ namespace Ami.BroAudio.Runtime
             _instanceWrapper?.Recycle();
             _instanceWrapper = null;
 
-            OnScheduleNextPlayback = null;
+            RequestNextPlayer = null;
             AudioTrack = null;
 
             ID = SoundID.Invalid;

--- a/Assets/BroAudio/Runtime/Player/AudioPlayer.Recycling.cs
+++ b/Assets/BroAudio/Runtime/Player/AudioPlayer.Recycling.cs
@@ -25,6 +25,9 @@ namespace Ami.BroAudio.Runtime
             DestroyAddedEffectComponents();
             ClearEvents();
             this.SafeStopCoroutine(_playbackControlCoroutine);
+            this.SafeStopCoroutine(_nextPlaybackSchedulingCoroutine);
+            _playbackControlCoroutine = null;
+            _nextPlaybackSchedulingCoroutine = null;
 
             if (TryGetMixerAndTrack(out _, out var track))
             {
@@ -45,7 +48,7 @@ namespace Ami.BroAudio.Runtime
             _instanceWrapper?.Recycle();
             _instanceWrapper = null;
 
-            OnPlaybackHandover = null;
+            OnScheduleNextPlayback = null;
             AudioTrack = null;
 
             ID = SoundID.Invalid;

--- a/Assets/BroAudio/Runtime/Player/AudioPlayer.Recycling.cs
+++ b/Assets/BroAudio/Runtime/Player/AudioPlayer.Recycling.cs
@@ -28,6 +28,7 @@ namespace Ami.BroAudio.Runtime
             this.SafeStopCoroutine(_nextPlaybackSchedulingCoroutine);
             _playbackControlCoroutine = null;
             _nextPlaybackSchedulingCoroutine = null;
+            _nextPlayer = null;
 
             if (TryGetMixerAndTrack(out _, out var track))
             {

--- a/Assets/BroAudio/Runtime/Player/AudioPlayer.Scheduling.cs
+++ b/Assets/BroAudio/Runtime/Player/AudioPlayer.Scheduling.cs
@@ -7,17 +7,15 @@ namespace Ami.BroAudio.Runtime
     [RequireComponent(typeof(AudioSource))]
     public partial class AudioPlayer : MonoBehaviour, IAudioPlayer, IPlayable, IRecyclable<AudioPlayer>
     {
-        private float _timeBeforeStartSchedule = 0f;
+        private double _timeBeforeStartSchedule;
 
-        private void SchedulePlayback(out bool hasScheduledPlay)
+        private void SchedulePlayback()
         {
-            hasScheduledPlay = false;
             if (_pref.ScheduledStartTime > 0d) // Scheduled has higher priority than clip.delay
             {
                 var dspTime = AudioSettings.dspTime;
                 AudioSource.PlayScheduled(System.Math.Max(_pref.ScheduledStartTime, dspTime));
-                _timeBeforeStartSchedule = (float)(_pref.ScheduledStartTime - AudioSettings.dspTime);
-                hasScheduledPlay = true;
+                _timeBeforeStartSchedule = _pref.ScheduledStartTime - dspTime;
             }
 
             if (_pref.ScheduledEndTime > 0d)
@@ -31,7 +29,7 @@ namespace Ami.BroAudio.Runtime
             if (_pref.ScheduledStartTime > 0d)
             {
                 // Recalculate the time when WaitForScheduledStartTime() is already running
-                _timeBeforeStartSchedule += (float)(dspTime - _pref.ScheduledStartTime);
+                _timeBeforeStartSchedule += dspTime - _pref.ScheduledStartTime;
             }
             _pref.ScheduledStartTime = dspTime;
 

--- a/Assets/BroAudio/Runtime/Player/AudioPlayer.Scheduling.cs
+++ b/Assets/BroAudio/Runtime/Player/AudioPlayer.Scheduling.cs
@@ -7,7 +7,7 @@ namespace Ami.BroAudio.Runtime
     [RequireComponent(typeof(AudioSource))]
     public partial class AudioPlayer : MonoBehaviour, IAudioPlayer, IPlayable, IRecyclable<AudioPlayer>
     {
-        private double _timeBeforeStartSchedule;
+        private double _secondsUntilScheduledStart;
 
         private void SchedulePlayback()
         {
@@ -15,7 +15,7 @@ namespace Ami.BroAudio.Runtime
             {
                 var dspTime = AudioSettings.dspTime;
                 AudioSource.PlayScheduled(System.Math.Max(_pref.ScheduledStartTime, dspTime));
-                _timeBeforeStartSchedule = _pref.ScheduledStartTime - dspTime;
+                _secondsUntilScheduledStart = _pref.ScheduledStartTime - dspTime;
             }
 
             if (_pref.ScheduledEndTime > 0d)
@@ -29,7 +29,7 @@ namespace Ami.BroAudio.Runtime
             if (_pref.ScheduledStartTime > 0d)
             {
                 // Recalculate the time when WaitForScheduledStartTime() is already running
-                _timeBeforeStartSchedule += dspTime - _pref.ScheduledStartTime;
+                _secondsUntilScheduledStart += dspTime - _pref.ScheduledStartTime;
             }
             _pref.ScheduledStartTime = dspTime;
 
@@ -85,10 +85,10 @@ namespace Ami.BroAudio.Runtime
 
         private IEnumerator WaitForScheduledStartTime()
         {
-            while (_timeBeforeStartSchedule > 0)
+            while (_secondsUntilScheduledStart > 0)
             {
                 yield return null;
-                _timeBeforeStartSchedule -= Utility.GetDeltaTime();
+                _secondsUntilScheduledStart -= Utility.GetDeltaTime();
             }
         }
 

--- a/Assets/BroAudio/Runtime/Player/PlaybackHandoverData.cs
+++ b/Assets/BroAudio/Runtime/Player/PlaybackHandoverData.cs
@@ -1,9 +1,12 @@
+using Ami.BroAudio.Data;
+
 namespace Ami.BroAudio.Runtime
 {
     public struct PlaybackHandoverData
     {
         public SoundID ID;
         public PlaybackPreference Pref;
+        public IBroAudioClip Clip;
         public EffectType PreviousTrackEffect;
         public float TrackVolume;
         public float Pitch;

--- a/Assets/BroAudio/Runtime/Player/PlaybackHandoverData.cs
+++ b/Assets/BroAudio/Runtime/Player/PlaybackHandoverData.cs
@@ -1,12 +1,9 @@
-using Ami.BroAudio.Data;
-
 namespace Ami.BroAudio.Runtime
 {
     public struct PlaybackHandoverData
     {
         public SoundID ID;
         public PlaybackPreference Pref;
-        public IBroAudioClip Clip;
         public EffectType PreviousTrackEffect;
         public float TrackVolume;
         public float Pitch;

--- a/Assets/BroAudio/Runtime/Player/PlaybackHandoverData.cs
+++ b/Assets/BroAudio/Runtime/Player/PlaybackHandoverData.cs
@@ -1,0 +1,14 @@
+using Ami.BroAudio.Data;
+
+namespace Ami.BroAudio.Runtime
+{
+    public struct PlaybackHandoverData
+    {
+        public SoundID ID;
+        public PlaybackPreference Pref;
+        public IBroAudioClip Clip;
+        public EffectType PreviousTrackEffect;
+        public float TrackVolume;
+        public float Pitch;
+    }
+}

--- a/Assets/BroAudio/Runtime/Player/PlaybackHandoverData.cs
+++ b/Assets/BroAudio/Runtime/Player/PlaybackHandoverData.cs
@@ -7,7 +7,7 @@ namespace Ami.BroAudio.Runtime
         public SoundID ID;
         public PlaybackPreference Pref;
         public IBroAudioClip Clip;
-        public EffectType PreviousTrackEffect;
+        public EffectType TrackEffect;
         public float TrackVolume;
         public float Pitch;
     }

--- a/Assets/BroAudio/Runtime/Player/PlaybackHandoverData.cs.meta
+++ b/Assets/BroAudio/Runtime/Player/PlaybackHandoverData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 789b9b25c10d56e4f9953348f334ccfa

--- a/Assets/BroAudio/Runtime/Player/PlaybackPreference.cs
+++ b/Assets/BroAudio/Runtime/Player/PlaybackPreference.cs
@@ -160,6 +160,11 @@ namespace Ami.BroAudio.Runtime
         {
             return Entity.PlayMode == MulticlipsPlayMode.Chained;
         }
+
+        public bool HasLoop()
+        {
+            return Entity.HasLoop(out _, out _);
+        }
         
         public bool IsLoop(LoopType targetType)
         {

--- a/Assets/BroAudio/Runtime/Player/PlaybackPreference.cs
+++ b/Assets/BroAudio/Runtime/Player/PlaybackPreference.cs
@@ -142,8 +142,7 @@ namespace Ami.BroAudio.Runtime
             {
                 return false;
             }
-            return IsLoop(LoopType.SeamlessLoop) || 
-                   (IsChainedMode() && ChainedModeStage == PlaybackStage.Start); // normal loop uses the same audio player to loop
+            return Entity.HasLoop(out _, out _);
         }
 
         public bool CanHandoverToEnd()

--- a/Assets/BroAudio/Runtime/SoundManager/SoundManager.Playback.cs
+++ b/Assets/BroAudio/Runtime/SoundManager/SoundManager.Playback.cs
@@ -9,7 +9,7 @@ namespace Ami.BroAudio.Runtime
     public partial class SoundManager : MonoBehaviour
     {
         private readonly Queue<IPlayable> _playbackQueue = new Queue<IPlayable>();
-        private AudioPlayer.NextPlaybackSchedule _nextPlaybackScheduleDelegate;
+        private AudioPlayer.HandoverPlayerFactory _scheduleHandover;
 
         #region Play
         public IAudioPlayer Play(SoundID id, float fadeIn, IPlayableValidator customValidator = null)
@@ -82,8 +82,8 @@ namespace Ami.BroAudio.Runtime
             
             if (pref.Entity.HasLoop(out _, out _) || pref.Entity.PlayMode == MulticlipsPlayMode.Chained)
             {
-                _nextPlaybackScheduleDelegate ??= ScheduleNextPlayback;
-                player.OnScheduleNextPlayback = _nextPlaybackScheduleDelegate;
+                _scheduleHandover ??= ScheduleNextPlayback;
+                player.RequestNextPlayer = _scheduleHandover;
             }
 
             // Start loading addressable clips if needed
@@ -117,11 +117,11 @@ namespace Ami.BroAudio.Runtime
 #endif
         }
 
-        private AudioPlayer ScheduleNextPlayback(PlaybackHandoverData data)
+        private AudioPlayer ScheduleNextPlayback(PlaybackHandoverData handover)
         {
             var newPlayer = _audioPlayerPool.Extract();
-            newPlayer.ReceiveHandover(data);
-            newPlayer.OnScheduleNextPlayback = _nextPlaybackScheduleDelegate;
+            newPlayer.ReceiveHandover(handover);
+            newPlayer.RequestNextPlayer = _scheduleHandover;
             return newPlayer;
         }
 

--- a/Assets/BroAudio/Runtime/SoundManager/SoundManager.Playback.cs
+++ b/Assets/BroAudio/Runtime/SoundManager/SoundManager.Playback.cs
@@ -9,7 +9,7 @@ namespace Ami.BroAudio.Runtime
     public partial class SoundManager : MonoBehaviour
     {
         private readonly Queue<IPlayable> _playbackQueue = new Queue<IPlayable>();
-        private AudioPlayer.PlaybackHandover _playbackHandoverDelegate;
+        private AudioPlayer.NextPlaybackSchedule _nextPlaybackScheduleDelegate;
 
         #region Play
         public IAudioPlayer Play(SoundID id, float fadeIn, IPlayableValidator customValidator = null)
@@ -64,7 +64,7 @@ namespace Ami.BroAudio.Runtime
 
         private IAudioPlayer PlayerToPlay(SoundID id, AudioPlayer player, PlaybackPreference pref)
         {
-            BroAudioType audioType = id.ToAudioType();
+            var audioType = id.ToAudioType();
             var wrapper = new AudioPlayerInstanceWrapper(player);
             player.SetInstanceWrapper(wrapper);
             player.SetPlaybackData(id, pref);
@@ -80,10 +80,10 @@ namespace Ami.BroAudio.Runtime
             _combFilteringPreventer ??= new Dictionary<SoundID, AudioPlayer>();
             _combFilteringPreventer[id] = player;
             
-            if (pref.IsLoop(LoopType.SeamlessLoop) || pref.Entity.PlayMode == MulticlipsPlayMode.Chained)
+            if (pref.Entity.HasLoop(out _, out _) || pref.Entity.PlayMode == MulticlipsPlayMode.Chained)
             {
-                _playbackHandoverDelegate ??= PlaybackHandover;
-                player.OnPlaybackHandover = _playbackHandoverDelegate;
+                _nextPlaybackScheduleDelegate ??= ScheduleNextPlayback;
+                player.OnScheduleNextPlayback = _nextPlaybackScheduleDelegate;
             }
 
             // Start loading addressable clips if needed
@@ -117,25 +117,12 @@ namespace Ami.BroAudio.Runtime
 #endif
         }
 
-        private void PlaybackHandover(SoundID id, InstanceWrapper<AudioPlayer> wrapper, PlaybackPreference pref, EffectType prevTrackEffect, float trackVolume, float pitch)
+        private AudioPlayer ScheduleNextPlayback(PlaybackHandoverData data)
         {
             var newPlayer = _audioPlayerPool.Extract();
-            wrapper.UpdateInstance(newPlayer);
-            newPlayer.SetInstanceWrapper(wrapper);
-
-            newPlayer.SetVolume(trackVolume);
-            newPlayer.SetPitch(pitch);
-            newPlayer.SetPlaybackData(id, pref);
-            newPlayer.Play();
-            if (pref.ScheduledEndTime > 0d)
-            {
-                newPlayer.SetScheduledEndTime(pref.ScheduledEndTime);
-            }
-#if !UNITY_WEBGL
-            newPlayer.SetTrackEffect(prevTrackEffect, SetEffectMode.Override);
-#endif
-
-            newPlayer.OnPlaybackHandover = PlaybackHandover;
+            newPlayer.ReceiveHandover(data);
+            newPlayer.OnScheduleNextPlayback = _nextPlaybackScheduleDelegate;
+            return newPlayer;
         }
 
         private void RemoveFromPreventer(AudioPlayer target)

--- a/Assets/BroAudio/Runtime/Utility/Utility.cs
+++ b/Assets/BroAudio/Runtime/Utility/Utility.cs
@@ -51,10 +51,10 @@ namespace Ami.BroAudio
             return (int)(sampleRate * seconds);
         }
 
-        public static float GetDuration(this IBroAudioClip clip)
+        public static double GetDuration(this IBroAudioClip clip)
         {
             var audioClip = clip.GetAudioClip();
-            return audioClip != null ?  audioClip.length - clip.StartPosition - clip.EndPosition : 0f;
+            return audioClip != null ? audioClip.GetPreciseLength() - clip.StartPosition - clip.EndPosition : 0d;
         }
 
         public static bool IsDefaultCurve(this AnimationCurve curve , float defaultValue)

--- a/Assets/BroAudio/Runtime/Utility/Utility.cs
+++ b/Assets/BroAudio/Runtime/Utility/Utility.cs
@@ -63,7 +63,7 @@ namespace Ami.BroAudio
             {
                 return true;
             }
-            else if(curve.length == 1 && curve[0].value == defaultValue)
+            else if(curve.length == 1 && Mathf.Approximately(curve[0].value, defaultValue))
             {
                 return true;
             }

--- a/Assets/BroAudio/Runtime/Utility/Utility.cs
+++ b/Assets/BroAudio/Runtime/Utility/Utility.cs
@@ -51,7 +51,7 @@ namespace Ami.BroAudio
             return (int)(sampleRate * seconds);
         }
 
-        public static double GetDuration(this IBroAudioClip clip)
+        public static double GetPlayableDuration(this IBroAudioClip clip)
         {
             var audioClip = clip.GetAudioClip();
             return audioClip != null ? audioClip.GetPreciseLength() - clip.StartPosition - clip.EndPosition : 0d;

--- a/Assets/BroAudio/Runtime/Utility/Utility.cs
+++ b/Assets/BroAudio/Runtime/Utility/Utility.cs
@@ -51,6 +51,12 @@ namespace Ami.BroAudio
             return (int)(sampleRate * seconds);
         }
 
+        public static float GetDuration(this IBroAudioClip clip)
+        {
+            var audioClip = clip.GetAudioClip();
+            return audioClip != null ?  audioClip.length - clip.StartPosition - clip.EndPosition : 0f;
+        }
+
         public static bool IsDefaultCurve(this AnimationCurve curve , float defaultValue)
         {
             if(curve == null || curve.length == 0)


### PR DESCRIPTION
Replaces the frame-polled coroutine restart in `AudioPlayer.PlayControl` with DSP-time scheduling. Each loop iteration now hands over to a fresh pooled player whose `AudioSource.PlayScheduled` fires on the same DSP boundary, eliminating the per-iteration frame jitter audible at loop seams.

## Commits

1. **Use PlayScheduled+handover for sample-accurate loops** — `OnPlaybackHandover` becomes `OnScheduleNextPlayback`; `ScheduleNextPlayback` builds the next player ~100 ms before the DSP boundary and `TriggerPlaybackHandover` swaps the `InstanceWrapper` over to it; new `PlaybackHandoverData` struct carries the state across the handover; `_timeBeforeStartSchedule` switched to `double` for DSP precision; new `IBroAudioClip.GetDuration()` helper.

2. **Simplify playback handover**
    - Extract `CanHandover(bool)` so `ScheduleNextPlayback` and `TriggerPlaybackHandover` share the gate; remove dead `newPref` local in `TriggerPlaybackHandover`.
    - Cache `hasLoop` in `PlayControl` (was evaluated twice).
    - Clear `_nextPlayer` in `Recycle` to prevent a stale handover reference reaching the next pooled use.
    - Make `ReceiveHandover` `internal` (only `SoundManager` invokes it).
    - `GetDuration` now returns `double` via `GetPreciseLength` so DSP-time math stays sample-accurate.
    - Fix indentation of the `PACKAGE_ADDRESSABLES` block, simplify `CanLoopIfIsChainedMode`'s redundant `IsChainedMode` check.

3. **Restore handover clip plumbing and pitch-adjust loop end time**
    - Carry `_clip` across the handover via `PlaybackHandoverData.Clip` so loop iterations reuse the same clip instead of re-rolling `PickNewClip` (set to `null` for chained mode so the next stage picks its own clip).
    - Pitch-adjust the computed `endDspTime` at both call sites: a clip played at 2&times; pitch finishes in half the wall-clock time, so divide duration by `AudioSource.pitch` (with a near-zero guard). User-supplied `_pref.ScheduledEndTime` is left untouched.

## Test plan

- [ ] Seamless loop has no audible seam jitter (compare to baseline).
- [ ] Regular loop: same clip is reused across iterations (multiclip Random entity should not re-roll on each loop).
- [ ] Chained mode: Start &rarr; Loop &rarr; End plays distinct clips, with Loop iterating the loop clip.
- [ ] Pitched playback (e.g. pitch = 0.5 and 2.0) loops at the correct DSP boundary.
- [ ] User-set `SetScheduledEndTime` still ends at the supplied DSP time regardless of pitch.
- [ ] Stop / Pause / UnPause still cancel the scheduled next player and don't leak `_nextPlayer` into the pool.