### PR TITLE
Fix scheduled playback timing for chained and looped audio

### DIFF
--- a/Assets/BroAudio/Runtime/Player/AudioPlayer.Playback.cs
+++ b/Assets/BroAudio/Runtime/Player/AudioPlayer.Playback.cs
@@ -123,11 +123,16 @@ namespace Ami.BroAudio.Runtime
             double dspTime = AudioSettings.dspTime;
             float pitch = AudioSource.pitch;
             double pitchAdjustedDuration = PitchAdjusted(_clip.GetPlayableDuration(), pitch);
-            double endDspTime = _pref.ScheduledEndTime <= 0 ? dspTime + pitchAdjustedDuration : _pref.ScheduledEndTime;
+            double startBaseTime = _pref.ScheduledStartTime > 0 ? _pref.ScheduledStartTime : dspTime;
+            double endDspTime = _pref.ScheduledEndTime <= 0 ? startBaseTime + pitchAdjustedDuration : _pref.ScheduledEndTime;
             if (_pref.HasLoop() && _pref.ScheduledStartTime <= 0)
             {
                 // TODO: might need a warmup time?
                 _pref.ScheduledStartTime = dspTime;
+                _pref.ScheduledEndTime = endDspTime;
+            }
+            else if (_pref.ScheduledStartTime > 0 && _pref.ScheduledEndTime <= 0)
+            {
                 _pref.ScheduledEndTime = endDspTime;
             }
 
@@ -241,18 +246,25 @@ namespace Ami.BroAudio.Runtime
                 newPref.ChainedModeStage = isEnd ? PlaybackStage.End : PlaybackStage.Loop;
             }
             
-            // TODO: it should be set in the new player, as it might pick a new clip!
-            double pitchAdjustedDuration = PitchAdjusted(_clip.GetPlayableDuration(), AudioSource.pitch);
+            bool needNewClip = _pref.IsChainedMode() && (isEnd || _pref.ChainedModeStage == PlaybackStage.Start);
+            // Reset so the new player can recalculate against its picked clip's duration.
+            newPref.ScheduledEndTime = 0;
             if (!isEnd && _pref.IsLoop(LoopType.SeamlessLoop) && newPref.HasFadeOut(_clip.FadeOut, out float fadeOut, out _))
             {
                 double fadeOutDspTime = endDspTime - fadeOut;
                 newPref.ScheduledStartTime = fadeOutDspTime;
-                newPref.ScheduledEndTime = fadeOutDspTime + pitchAdjustedDuration;
+                if (!needNewClip)
+                {
+                    newPref.ScheduledEndTime = fadeOutDspTime + PitchAdjusted(_clip.GetPlayableDuration(), AudioSource.pitch);
+                }
             }
             else
             {
                 newPref.ScheduledStartTime = endDspTime;
-                newPref.ScheduledEndTime = endDspTime + pitchAdjustedDuration;
+                if (!needNewClip)
+                {
+                    newPref.ScheduledEndTime = endDspTime + PitchAdjusted(_clip.GetPlayableDuration(), AudioSource.pitch);
+                }
             }
             // TODO: calculate the real warmup time
             var warmUpTime = isEnd ? 0 : 0.1;
@@ -261,7 +273,6 @@ namespace Ami.BroAudio.Runtime
                 yield return null;
             }
 
-            bool needNewClip = _pref.IsChainedMode() && (isEnd || _pref.ChainedModeStage == PlaybackStage.Start);
             var handover = new PlaybackHandoverData()
             {
                 ID = ID,


### PR DESCRIPTION
## Summary
This PR fixes audio playback scheduling to correctly handle cases where a scheduled start time is explicitly set, and improves handling of chained mode playback to allow proper clip selection before calculating end times.

## Key Changes
- **Scheduled start time handling**: When `ScheduledStartTime` is explicitly set, use it as the base time for calculating `ScheduledEndTime` instead of always using the current DSP time
- **Chained mode clip selection**: Reset `ScheduledEndTime` to 0 when a new clip might be selected in chained mode, allowing the new player to recalculate the end time based on its actual picked clip's duration
- **Conditional end time calculation**: Only set `ScheduledEndTime` in `ScheduleNextPlayback` when the current clip will be reused (not when a new clip will be selected in chained mode)
- **Code organization**: Moved `needNewClip` variable declaration earlier to improve logic flow and reduce redundant duration calculations

## Implementation Details
- The fix ensures that when both `ScheduledStartTime` and `ScheduledEndTime` are set, they work together correctly for seamless looping and chained playback
- For chained mode transitions (Start→Loop→End), the end time is deferred to the new player so it can account for the potentially different clip duration
- This prevents timing mismatches that could occur when a new clip with a different duration is selected during chained playback

https://claude.ai/code/session_012YNEQ29pwKgcv6EbN1PWD2