### PR TITLE
Add null checks for audio player handover operations

### DIFF
--- a/Assets/BroAudio/Runtime/Player/AudioPlayer.Playback.cs
+++ b/Assets/BroAudio/Runtime/Player/AudioPlayer.Playback.cs
@@ -295,7 +295,7 @@ namespace Ami.BroAudio.Runtime
 
         private void BeginHandover(bool isEnd = false)
         {
-            if (!CanHandover(isEnd))
+            if (!CanHandover(isEnd) || _instanceWrapper == null || _nextPlayer == null)
             {
                 return;
             }
@@ -394,7 +394,7 @@ namespace Ami.BroAudio.Runtime
             IsStopping = true;
             _pref.SetNextFadeOut(overrideFade);
 
-            if (_pref.CanHandoverToEnd())
+            if (_instanceWrapper != null && _pref.CanHandoverToEnd())
             {
                 this.RestartCoroutine(ScheduleNextPlayback(AudioSettings.dspTime, isEnd: true), ref _handoverScheduleCoroutine);  // Start the next playback immediately
                 BeginHandover(isEnd: true);


### PR DESCRIPTION
## Summary
Added defensive null checks to prevent potential null reference exceptions during audio player handover operations.

## Key Changes
- **BeginHandover()**: Added null checks for `_instanceWrapper` and `_nextPlayer` before proceeding with handover logic
- **StopControl()**: Added null check for `_instanceWrapper` before calling `CanHandoverToEnd()`

## Implementation Details
These changes ensure that handover operations gracefully exit early if critical player components are not initialized, preventing crashes that could occur if handover is triggered during incomplete initialization or cleanup states. The null checks follow the existing pattern of early returns when preconditions are not met.

https://claude.ai/code/session_01RoJa5upked6ZPc5R6PL9vp