### PR TITLE
Add "Change Clip Per Loop" feature for audio entities

### DIFF
--- a/Assets/BroAudio/Editor/EntityPropertyDrawer/AudioEntityEditor.AdditionalProperties.cs
+++ b/Assets/BroAudio/Editor/EntityPropertyDrawer/AudioEntityEditor.AdditionalProperties.cs
@@ -45,7 +45,8 @@ namespace Ami.BroAudio.Editor
             {
                 lineCount++;
             }
-            if (loopProp.boolValue || seamlessProp.boolValue)
+            var clipsProp = serializedObject.FindProperty(nameof(AudioEntity.Clips));
+            if ((loopProp.boolValue || seamlessProp.boolValue) && clipsProp.arraySize > 1)
             {
                 lineCount++;
             }
@@ -345,7 +346,18 @@ namespace Ami.BroAudio.Editor
             _loopingRects[1] = new Rect(loopRect) { width = 200f, x = _loopingRects[0].xMax };
             DrawToggleGroup(loopRect, _loopingLabel, _loopingToggles, _loopingRects);
 
-            if (loopProp.boolValue || seamlessProp.boolValue)
+            Rect totalRect = loopRect;
+            var data = GetLoopData(loopProp.boolValue, seamlessProp.boolValue);
+            if (seamlessProp.boolValue)
+            {
+                DrawSeamlessSetting(position, ref data);
+                totalRect.height += EditorGUIUtility.singleLineHeight;
+            }
+
+            PropertyClipboard.HandleClipboardContextMenu(totalRect, serializedObject, data, OnPasteLoopSettingValues);
+
+            var clipsProp = serializedObject.FindProperty(nameof(AudioEntity.Clips));
+            if ((loopProp.boolValue || seamlessProp.boolValue) && clipsProp.arraySize > 1)
             {
                 SerializedProperty entityFlagsProp = serializedObject.FindBackingFieldProperty(nameof(AudioEntity.Flags));
                 int entityFlags = entityFlagsProp.intValue;
@@ -364,16 +376,6 @@ namespace Ami.BroAudio.Editor
                     serializedObject.ApplyModifiedProperties();
                 }
             }
-
-            Rect totalRect = loopRect;
-            var data = GetLoopData(loopProp.boolValue, seamlessProp.boolValue);
-            if (seamlessProp.boolValue)
-            {
-                DrawSeamlessSetting(position, ref data);
-                totalRect.height += EditorGUIUtility.singleLineHeight;
-            }
-                
-            PropertyClipboard.HandleClipboardContextMenu(totalRect, serializedObject, data, OnPasteLoopSettingValues);
             
             static void OnPasteLoopSettingValues(SerializedObject serializedObject, LoopData value)
             {

--- a/Assets/BroAudio/Editor/EntityPropertyDrawer/AudioEntityEditor.AdditionalProperties.cs
+++ b/Assets/BroAudio/Editor/EntityPropertyDrawer/AudioEntityEditor.AdditionalProperties.cs
@@ -21,6 +21,7 @@ namespace Ami.BroAudio.Editor
         
         private readonly GUIContent _masterVolLabel = new GUIContent("Master Volume","Represent the master volume of all clips");
         private readonly GUIContent _loopingLabel = new GUIContent("Looping");
+        private readonly GUIContent _changeClipPerLoopLabel = new GUIContent("Change Clip Per Loop", "Pick a new clip on every loop iteration");
         private readonly GUIContent _seamlessLabel = new GUIContent("Seamless Setting");
         private readonly GUIContent _pitchLabel = new GUIContent(nameof(AudioEntity.Pitch));
         private readonly GUIContent _spatialLabel = new GUIContent("Spatial & Mix Settings", "Configures 3D sound settings, Stereo Pan, Reverb Zone Mix, and other audio properties");
@@ -38,8 +39,13 @@ namespace Ami.BroAudio.Editor
             ConvertUnityEverythingFlagsToAll(ref drawFlags);
             int intBits = 32;
             int lineCount = GetDrawingLineCount(drawFlags, OverallDrawedPropStartIndex, intBits, IsDefaultValue);
+            var loopProp = serializedObject.FindBackingFieldProperty(nameof(AudioEntity.Loop));
             var seamlessProp = serializedObject.FindBackingFieldProperty(nameof(AudioEntity.SeamlessLoop));
             if (seamlessProp.boolValue)
+            {
+                lineCount++;
+            }
+            if (loopProp.boolValue || seamlessProp.boolValue)
             {
                 lineCount++;
             }
@@ -338,6 +344,26 @@ namespace Ami.BroAudio.Editor
             _loopingRects[0] = new Rect(loopRect) { width = 100f, x = loopRect.x + EditorGUIUtility.labelWidth };
             _loopingRects[1] = new Rect(loopRect) { width = 200f, x = _loopingRects[0].xMax };
             DrawToggleGroup(loopRect, _loopingLabel, _loopingToggles, _loopingRects);
+
+            if (loopProp.boolValue || seamlessProp.boolValue)
+            {
+                SerializedProperty entityFlagsProp = serializedObject.FindBackingFieldProperty(nameof(AudioEntity.Flags));
+                int entityFlags = entityFlagsProp.intValue;
+                bool changeClipPerLoop = ((AudioEntityFlag)entityFlags).Contains(AudioEntityFlag.ChangeClipPerLoop);
+                Rect changeClipRect = GetRectAndIterateLine(position);
+                changeClipRect.xMin += EditorGUIUtility.labelWidth;
+                EditorGUI.BeginChangeCheck();
+                changeClipPerLoop = EditorGUI.ToggleLeft(changeClipRect, _changeClipPerLoopLabel, changeClipPerLoop);
+                if (EditorGUI.EndChangeCheck())
+                {
+                    if (changeClipPerLoop)
+                        AddFlag(ref entityFlags, (int)AudioEntityFlag.ChangeClipPerLoop);
+                    else
+                        RemoveFlag(ref entityFlags, (int)AudioEntityFlag.ChangeClipPerLoop);
+                    entityFlagsProp.intValue = entityFlags;
+                    serializedObject.ApplyModifiedProperties();
+                }
+            }
 
             Rect totalRect = loopRect;
             var data = GetLoopData(loopProp.boolValue, seamlessProp.boolValue);

--- a/Assets/BroAudio/Runtime/DataStruct/Core/AudioEntity.cs
+++ b/Assets/BroAudio/Runtime/DataStruct/Core/AudioEntity.cs
@@ -33,6 +33,7 @@ namespace Ami.BroAudio.Data
         [field: SerializeField] public float PitchRandomRange { get; private set; }
         [field: SerializeField] public float VolumeRandomRange { get; private set; }
         [field: SerializeField] public RandomFlag RandomFlags { get; private set; }
+        [field: SerializeField] public AudioEntityFlag Flags { get; private set; }
         public PlaybackGroup PlaybackGroup => _group ? _group : _upperGroup;
 
         IReadOnlyList<IBroAudioClip> IReadOnlyAudioEntity.Clips => Clips;

--- a/Assets/BroAudio/Runtime/Enums/AudioEntityFlag.cs
+++ b/Assets/BroAudio/Runtime/Enums/AudioEntityFlag.cs
@@ -1,0 +1,9 @@
+namespace Ami.Extension
+{
+    [System.Flags]
+    public enum AudioEntityFlag
+    {
+        None = 0,
+        ChangeClipPerLoop = 1 << 0,
+    }
+}

--- a/Assets/BroAudio/Runtime/Enums/AudioEntityFlag.cs.meta
+++ b/Assets/BroAudio/Runtime/Enums/AudioEntityFlag.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6bf52bf15dbfcb845adeefd6c8e59015

--- a/Assets/BroAudio/Runtime/Interface/IAudioEntity.cs
+++ b/Assets/BroAudio/Runtime/Interface/IAudioEntity.cs
@@ -16,5 +16,6 @@ namespace Ami.BroAudio.Data
 		float GetRandomValue(float baseValue, RandomFlag flags);
         void ResetMultiClipStrategy();
         MulticlipsPlayMode PlayMode { get; }
-    } 
+        AudioEntityFlag Flags { get; }
+    }
 }

--- a/Assets/BroAudio/Runtime/Interface/IReadOnlyAudioEntity.cs
+++ b/Assets/BroAudio/Runtime/Interface/IReadOnlyAudioEntity.cs
@@ -19,6 +19,7 @@ namespace Ami.BroAudio.Data
         float PitchRandomRange { get; }
         float VolumeRandomRange { get; }
         RandomFlag RandomFlags { get; }
+        AudioEntityFlag Flags { get; }
         PlaybackGroup PlaybackGroup { get; }
         MulticlipsPlayMode PlayMode { get; }
     }

--- a/Assets/BroAudio/Runtime/Player/AudioPlayer.Playback.cs
+++ b/Assets/BroAudio/Runtime/Player/AudioPlayer.Playback.cs
@@ -74,7 +74,7 @@ namespace Ami.BroAudio.Runtime
                 _audioTypeVolume.Complete(audioTypePref.Volume, false);
             }
             _clipVolume.Complete(0f, false);
-            _clip ??= _pref.PickNewClip(); // TODO: Add change clip for each loop option
+            _clip ??= _pref.PickNewClip();
             if (_clip == null)
             {
                 EndPlaying();
@@ -265,7 +265,9 @@ namespace Ami.BroAudio.Runtime
                 newPref.ScheduledEndTime -= fadeOut;
             }
 
-            bool needNewClip = _pref.IsChainedMode() && (isEnd || _pref.ChainedModeStage == PlaybackStage.Start);
+            bool changePerLoop = _pref.Entity.Flags.Contains(AudioEntityFlag.ChangeClipPerLoop);
+            bool needNewClip = changePerLoop
+                            || (_pref.IsChainedMode() && (isEnd || _pref.ChainedModeStage == PlaybackStage.Start));
             if (needNewClip)
             {
                 // Reset so the new player can recalculate against its picked clip's duration.

--- a/Assets/BroAudio/Runtime/Utility/Utility.cs
+++ b/Assets/BroAudio/Runtime/Utility/Utility.cs
@@ -25,6 +25,11 @@ namespace Ami.BroAudio
         {
             return ((int)flags & (int)targetFlag) != 0;
         }
+
+        public static bool Contains(this AudioEntityFlag flags, AudioEntityFlag targetFlag)
+        {
+            return ((int)flags & (int)targetFlag) != 0;
+        }
         #endregion
 
         public static BroAudioType ConvertEverythingFlag(this BroAudioType audioType)


### PR DESCRIPTION
## Summary
This PR adds a new "Change Clip Per Loop" feature that allows audio entities to pick a new clip on every loop iteration, providing more dynamic audio playback behavior.

## Key Changes
- **New AudioEntityFlag enum**: Created `AudioEntityFlag` enum with `ChangeClipPerLoop` flag to control clip selection behavior
- **Editor UI**: Added "Change Clip Per Loop" toggle in the AudioEntityEditor that appears when looping or seamless looping is enabled
- **Runtime logic**: Modified `AudioPlayer.Playback.cs` to check the `ChangeClipPerLoop` flag and pick a new clip during loop iterations
- **Interface updates**: Added `Flags` property to `IAudioEntity` and `IReadOnlyAudioEntity` interfaces
- **Data model**: Added `Flags` field to `AudioEntity` for serialization
- **Utility extension**: Added `Contains()` extension method for `AudioEntityFlag` to check flag values
- **Height calculation**: Updated editor height calculation to account for the new toggle when looping is enabled

## Implementation Details
- The "Change Clip Per Loop" toggle is conditionally displayed only when either regular looping or seamless looping is enabled
- The feature integrates with the existing chained mode logic, allowing clips to be changed either per loop or during chained playback stages
- The flag is stored as a serialized field on the AudioEntity and checked during playback scheduling

https://claude.ai/code/session_018rBaHshzj49tLsvdJRJYhd