### PR TITLE
Unify localization and addressables asset loading APIs

### DIFF
--- a/Assets/BroAudio/Runtime/BroAudio.cs
+++ b/Assets/BroAudio/Runtime/BroAudio.cs
@@ -303,24 +303,6 @@ namespace Ami.BroAudio
         #endregion
 #endif
 
-#if PACKAGE_LOCALIZATION
-        /// <summary>
-        /// Preloads the AudioClip for the given entity's current locale into the Addressables cache.
-        /// After this call, playback via <c>WaitForCompletion()</c> will return instantly.
-        /// Subscribe to <c>LocalizationSettings.SelectedLocaleChanged</c> is handled automatically;
-        /// when the locale changes the cache is refreshed. Call <see cref="ReleaseLocalizationPreload"/>
-        /// when the entity is no longer needed to avoid memory leaks.
-        /// </summary>
-        public static AsyncOperationHandle<AudioClip> PreloadLocalizationAssets(SoundID id)
-            => SoundManager.Instance.PreloadLocalizationAssets(id);
-
-        /// <summary>
-        /// Releases the preloaded Addressables handle for the given entity.
-        /// </summary>
-        public static void ReleaseLocalizationPreload(SoundID id)
-            => SoundManager.Instance.ReleaseLocalizationPreload(id);
-#endif
-
 #if PACKAGE_ADDRESSABLES || PACKAGE_LOCALIZATION
         public static bool IsLoaded(SoundID id)
             => SoundManager.Instance.IsLoaded(id);

--- a/Assets/BroAudio/Runtime/BroAudio.cs
+++ b/Assets/BroAudio/Runtime/BroAudio.cs
@@ -319,15 +319,14 @@ namespace Ami.BroAudio
             => SoundManager.Instance.LoadAllAssetsAsync(id);
 
         /// <summary>
-        /// Loads the first audio clip in the entity
+        /// Loads the first audio clip in the entity, or the active locale's clip in Localization mode.
         /// </summary>
         public static AsyncOperationHandle<AudioClip> LoadAssetAsync(SoundID id)
             => LoadAssetAsync(id, 0);
 
         /// <summary>
         /// Loads the audio clip in the entity's clip list by index.
-        /// For Localization-mode entities, <paramref name="clipIndex"/> is ignored;
-        /// one entry resolves to one clip per active locale.
+        /// In Localization mode, <paramref name="clipIndex"/> is ignored and the active locale's clip is loaded.
         /// </summary>
         public static AsyncOperationHandle<AudioClip> LoadAssetAsync(SoundID id, int clipIndex)
             => SoundManager.Instance.LoadAssetAsync(id, clipIndex);
@@ -340,14 +339,15 @@ namespace Ami.BroAudio
             => SoundManager.Instance.ReleaseAllAssets(id);
 
         /// <summary>
-        /// Releases the first audio clip in the entity
+        /// Releases the first audio clip in the entity, or the active locale's clip in Localization mode.
         /// </summary>
         /// <param name="id"></param>
         public static void ReleaseAsset(SoundID id)
             => SoundManager.Instance.ReleaseAsset(id, 0);
 
         /// <summary>
-        /// Releases the audio clip in the entity's clip list by index
+        /// Releases the audio clip in the entity's clip list by index.
+        /// In Localization mode, <paramref name="clipIndex"/> is ignored and the active locale's clip is released.
         /// </summary>
         /// <param name="id"></param>
         /// <param name="clipIndex"></param>

--- a/Assets/BroAudio/Runtime/BroAudio.cs
+++ b/Assets/BroAudio/Runtime/BroAudio.cs
@@ -321,7 +321,7 @@ namespace Ami.BroAudio
             => SoundManager.Instance.ReleaseLocalizationPreload(id);
 #endif
 
-#if PACKAGE_ADDRESSABLES
+#if PACKAGE_ADDRESSABLES || PACKAGE_LOCALIZATION
         public static bool IsLoaded(SoundID id)
             => SoundManager.Instance.IsLoaded(id);
 
@@ -333,7 +333,7 @@ namespace Ami.BroAudio
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        public static AsyncOperationHandle<IList<AudioClip>> LoadAllAssetsAsync(SoundID id) 
+        public static AsyncOperationHandle<IList<AudioClip>> LoadAllAssetsAsync(SoundID id)
             => SoundManager.Instance.LoadAllAssetsAsync(id);
 
         /// <summary>
@@ -343,7 +343,9 @@ namespace Ami.BroAudio
             => LoadAssetAsync(id, 0);
 
         /// <summary>
-        /// Loads the audio clip in the entity's clip list by index
+        /// Loads the audio clip in the entity's clip list by index.
+        /// For Localization-mode entities, <paramref name="clipIndex"/> is ignored;
+        /// one entry resolves to one clip per active locale.
         /// </summary>
         public static AsyncOperationHandle<AudioClip> LoadAssetAsync(SoundID id, int clipIndex)
             => SoundManager.Instance.LoadAssetAsync(id, clipIndex);
@@ -352,7 +354,7 @@ namespace Ami.BroAudio
         /// Releases all the audio clips in the entity
         /// </summary>
         /// <param name="id"></param>
-        public static void ReleaseAllAssets(SoundID id) 
+        public static void ReleaseAllAssets(SoundID id)
             => SoundManager.Instance.ReleaseAllAssets(id);
 
         /// <summary>

--- a/Assets/BroAudio/Runtime/SoundManager/SoundManager.Addressables.cs
+++ b/Assets/BroAudio/Runtime/SoundManager/SoundManager.Addressables.cs
@@ -1,4 +1,4 @@
-#if PACKAGE_ADDRESSABLES
+#if PACKAGE_ADDRESSABLES || PACKAGE_LOCALIZATION
 using UnityEngine;
 using System.Collections.Generic;
 using UnityEngine.ResourceManagement.AsyncOperations;
@@ -40,6 +40,13 @@ namespace Ami.BroAudio.Runtime
 
         public AsyncOperationHandle<IList<AudioClip>> LoadAllAssetsAsync(SoundID id)
         {
+#if PACKAGE_LOCALIZATION
+            if (TryGetEntity(id, out var anyEntity) && anyEntity is AudioEntity localizationEntity
+                && localizationEntity.PlayMode == MulticlipsPlayMode.Localization)
+            {
+                return LoadAllLocalizedAssetsAsync(id, localizationEntity);
+            }
+#endif
             if (TryGetAddressableEntity(id, out var entity))
             {
                 var result = entity.LoadAssetsAsync();
@@ -52,6 +59,13 @@ namespace Ami.BroAudio.Runtime
 
         public AsyncOperationHandle<AudioClip> LoadAssetAsync(SoundID id, int clipIndex)
         {
+#if PACKAGE_LOCALIZATION
+            if (TryGetEntity(id, out var anyEntity) && anyEntity is AudioEntity localizationEntity
+                && localizationEntity.PlayMode == MulticlipsPlayMode.Localization)
+            {
+                return LoadLocalizedAssetAsync(id, localizationEntity);
+            }
+#endif
             if (TryGetAddressableEntity(id, out var entity) && clipIndex >= 0 && clipIndex < entity.Clips.Length)
             {
                 var clip = entity.Clips[clipIndex];

--- a/Assets/BroAudio/Runtime/SoundManager/SoundManager.Addressables.cs
+++ b/Assets/BroAudio/Runtime/SoundManager/SoundManager.Addressables.cs
@@ -78,6 +78,14 @@ namespace Ami.BroAudio.Runtime
 
         public void ReleaseAllAssets(SoundID id)
         {
+#if PACKAGE_LOCALIZATION
+            if (TryGetEntity(id, out var anyEntity) && anyEntity is AudioEntity localizationEntity
+                && localizationEntity.PlayMode == MulticlipsPlayMode.Localization)
+            {
+                ReleaseLocalizationHandleInternal(id);
+                return;
+            }
+#endif
             if (TryGetAddressableEntity(id, out var entity))
             {
                 entity.ReleaseAllAssets();
@@ -86,6 +94,14 @@ namespace Ami.BroAudio.Runtime
 
         public void ReleaseAsset(SoundID id, int clipIndex)
         {
+#if PACKAGE_LOCALIZATION
+            if (TryGetEntity(id, out var anyEntity) && anyEntity is AudioEntity localizationEntity
+                && localizationEntity.PlayMode == MulticlipsPlayMode.Localization)
+            {
+                ReleaseLocalizationHandleInternal(id);
+                return;
+            }
+#endif
             if (TryGetAddressableEntity(id, out var entity) && clipIndex >= 0 && clipIndex < entity.Clips.Length)
             {
                 entity.Clips[clipIndex].ReleaseAsset();

--- a/Assets/BroAudio/Runtime/SoundManager/SoundManager.Localization.cs
+++ b/Assets/BroAudio/Runtime/SoundManager/SoundManager.Localization.cs
@@ -35,29 +35,19 @@ namespace Ami.BroAudio.Runtime
                 return default;
             }
 
-            AsyncOperationHandle<AudioClip> handle = LoadLocalizedAssetAsync(id, audioEntity);
-            if (!handle.IsValid())
-            {
-                return default;
-            }
-
-            _preloadedLocalizationHandles ??= new Dictionary<SoundID, AsyncOperationHandle<AudioClip>>();
-
-            // Release any existing handle for this id before storing the new one
-            ReleaseLocalizationHandleInternal(id);
-
             if (!_isSubscribedToLocaleChanged)
             {
                 LocalizationSettings.SelectedLocaleChanged += OnSelectedLocaleChanged;
                 _isSubscribedToLocaleChanged = true;
             }
 
-            _preloadedLocalizationHandles[id] = handle;
-            return handle;
+            return LoadLocalizedAssetAsync(id, audioEntity);
         }
 
         /// <summary>
-        ///     Resolves the locale-correct AudioClip for the given Localization-mode entity.
+        ///     Resolves the locale-correct AudioClip for the given Localization-mode entity, caching the
+        ///     handle by SoundID so subsequent calls return the same handle and a paired
+        ///     <see cref="SoundManager.ReleaseAsset(SoundID,int)"/> can release it.
         ///     Returns <c>default</c> and logs a warning if the table or entry reference is empty.
         /// </summary>
         private AsyncOperationHandle<AudioClip> LoadLocalizedAssetAsync(SoundID id, AudioEntity audioEntity)
@@ -70,8 +60,17 @@ namespace Ami.BroAudio.Runtime
                 return default;
             }
 
-            return LocalizationSettings.AssetDatabase
+            _preloadedLocalizationHandles ??= new Dictionary<SoundID, AsyncOperationHandle<AudioClip>>();
+
+            if (_preloadedLocalizationHandles.TryGetValue(id, out AsyncOperationHandle<AudioClip> cached) && cached.IsValid())
+            {
+                return cached;
+            }
+
+            AsyncOperationHandle<AudioClip> handle = LocalizationSettings.AssetDatabase
                 .GetLocalizedAssetAsync<AudioClip>(audioEntity.LocalizationTable, audioEntity.LocalizationEntry);
+            _preloadedLocalizationHandles[id] = handle;
+            return handle;
         }
 
         /// <summary>

--- a/Assets/BroAudio/Runtime/SoundManager/SoundManager.Localization.cs
+++ b/Assets/BroAudio/Runtime/SoundManager/SoundManager.Localization.cs
@@ -16,38 +16,11 @@ namespace Ami.BroAudio.Runtime
         private Dictionary<SoundID, AsyncOperationHandle<AudioClip>> _preloadedLocalizationHandles;
 
         /// <summary>
-        ///     Preloads the AudioClip for the given entity's current locale into the Addressables cache.
-        ///     After this call, <c>WaitForCompletion()</c> during playback will return instantly.
-        ///     Call <see cref="ReleaseLocalizationPreload" /> when the entity is no longer needed.
-        /// </summary>
-        public AsyncOperationHandle<AudioClip> PreloadLocalizationAssets(SoundID id)
-        {
-            if (!TryGetEntity(id, out IAudioEntity entity))
-            {
-                return default;
-            }
-
-            var audioEntity = entity as AudioEntity;
-            if (audioEntity.PlayMode != MulticlipsPlayMode.Localization)
-            {
-                Debug.LogWarning(Utility.LogTitle +
-                                 $"[{nameof(PreloadLocalizationAssets)}] Entity '{audioEntity.Name}' is not in Localization mode.");
-                return default;
-            }
-
-            if (!_isSubscribedToLocaleChanged)
-            {
-                LocalizationSettings.SelectedLocaleChanged += OnSelectedLocaleChanged;
-                _isSubscribedToLocaleChanged = true;
-            }
-
-            return LoadLocalizedAssetAsync(id, audioEntity);
-        }
-
-        /// <summary>
         ///     Resolves the locale-correct AudioClip for the given Localization-mode entity, caching the
         ///     handle by SoundID so subsequent calls return the same handle and a paired
         ///     <see cref="SoundManager.ReleaseAsset(SoundID,int)"/> can release it.
+        ///     Subscribes to <see cref="LocalizationSettings.SelectedLocaleChanged"/> on first cache add so
+        ///     the cache stays in sync with the active locale.
         ///     Returns <c>default</c> and logs a warning if the table or entry reference is empty.
         /// </summary>
         private AsyncOperationHandle<AudioClip> LoadLocalizedAssetAsync(SoundID id, AudioEntity audioEntity)
@@ -65,6 +38,12 @@ namespace Ami.BroAudio.Runtime
             if (_preloadedLocalizationHandles.TryGetValue(id, out AsyncOperationHandle<AudioClip> cached) && cached.IsValid())
             {
                 return cached;
+            }
+
+            if (!_isSubscribedToLocaleChanged)
+            {
+                LocalizationSettings.SelectedLocaleChanged += OnSelectedLocaleChanged;
+                _isSubscribedToLocaleChanged = true;
             }
 
             AsyncOperationHandle<AudioClip> handle = LocalizationSettings.AssetDatabase
@@ -90,14 +69,6 @@ namespace Ami.BroAudio.Runtime
                 IList<AudioClip> result = new List<AudioClip> { op.Result };
                 return Addressables.ResourceManager.CreateCompletedOperation(result, string.Empty);
             });
-        }
-
-        /// <summary>
-        ///     Releases the preloaded Addressables handle for the given entity, freeing the cached AudioClip.
-        /// </summary>
-        public void ReleaseLocalizationPreload(SoundID id)
-        {
-            ReleaseLocalizationHandleInternal(id);
         }
 
         private void ReleaseLocalizationHandleInternal(SoundID id)
@@ -136,7 +107,11 @@ namespace Ami.BroAudio.Runtime
 
             foreach (SoundID id in ids)
             {
-                PreloadLocalizationAssets(id);
+                if (TryGetEntity(id, out IAudioEntity entity) && entity is AudioEntity audioEntity
+                    && audioEntity.PlayMode == MulticlipsPlayMode.Localization)
+                {
+                    LoadLocalizedAssetAsync(id, audioEntity);
+                }
             }
         }
 

--- a/Assets/BroAudio/Runtime/SoundManager/SoundManager.Localization.cs
+++ b/Assets/BroAudio/Runtime/SoundManager/SoundManager.Localization.cs
@@ -35,17 +35,15 @@ namespace Ami.BroAudio.Runtime
                 return default;
             }
 
-            if (audioEntity.LocalizationTable.ReferenceType == TableReference.Type.Empty ||
-                audioEntity.LocalizationEntry.ReferenceType == TableEntryReference.Type.Empty)
+            AsyncOperationHandle<AudioClip> handle = LoadLocalizedAssetAsync(id, audioEntity);
+            if (!handle.IsValid())
             {
-                Debug.LogWarning(Utility.LogTitle +
-                                 $"[{nameof(PreloadLocalizationAssets)}] LocalizationTable or LocalizationEntry is not set on entity '{audioEntity.Name}'.");
                 return default;
             }
 
             _preloadedLocalizationHandles ??= new Dictionary<SoundID, AsyncOperationHandle<AudioClip>>();
 
-            // Release any existing handle for this id before fetching a new one
+            // Release any existing handle for this id before storing the new one
             ReleaseLocalizationHandleInternal(id);
 
             if (!_isSubscribedToLocaleChanged)
@@ -54,10 +52,45 @@ namespace Ami.BroAudio.Runtime
                 _isSubscribedToLocaleChanged = true;
             }
 
-            AsyncOperationHandle<AudioClip> handle = LocalizationSettings.AssetDatabase
-                .GetLocalizedAssetAsync<AudioClip>(audioEntity.LocalizationTable, audioEntity.LocalizationEntry);
             _preloadedLocalizationHandles[id] = handle;
             return handle;
+        }
+
+        /// <summary>
+        ///     Resolves the locale-correct AudioClip for the given Localization-mode entity.
+        ///     Returns <c>default</c> and logs a warning if the table or entry reference is empty.
+        /// </summary>
+        private AsyncOperationHandle<AudioClip> LoadLocalizedAssetAsync(SoundID id, AudioEntity audioEntity)
+        {
+            if (audioEntity.LocalizationTable.ReferenceType == TableReference.Type.Empty ||
+                audioEntity.LocalizationEntry.ReferenceType == TableEntryReference.Type.Empty)
+            {
+                Debug.LogWarning(Utility.LogTitle +
+                                 $"LocalizationTable or LocalizationEntry is not set on entity '{audioEntity.Name}'.");
+                return default;
+            }
+
+            return LocalizationSettings.AssetDatabase
+                .GetLocalizedAssetAsync<AudioClip>(audioEntity.LocalizationTable, audioEntity.LocalizationEntry);
+        }
+
+        /// <summary>
+        ///     Wraps the single resolved localized clip into an <see cref="IList{AudioClip}"/> handle so the
+        ///     return type matches the Addressables path of <see cref="LoadAllAssetsAsync"/>.
+        /// </summary>
+        private AsyncOperationHandle<IList<AudioClip>> LoadAllLocalizedAssetsAsync(SoundID id, AudioEntity audioEntity)
+        {
+            AsyncOperationHandle<AudioClip> clipHandle = LoadLocalizedAssetAsync(id, audioEntity);
+            if (!clipHandle.IsValid())
+            {
+                return default;
+            }
+
+            return Addressables.ResourceManager.CreateChainOperation<IList<AudioClip>, AudioClip>(clipHandle, op =>
+            {
+                IList<AudioClip> result = new List<AudioClip> { op.Result };
+                return Addressables.ResourceManager.CreateCompletedOperation(result, string.Empty);
+            });
         }
 
         /// <summary>

--- a/Assets/BroAudio/Runtime/Utility/ClipSelection/LocalizationClipStrategy.cs
+++ b/Assets/BroAudio/Runtime/Utility/ClipSelection/LocalizationClipStrategy.cs
@@ -47,7 +47,7 @@ namespace Ami.BroAudio.Runtime
                 Debug.LogWarning(Utility.LogTitle +
                     $"Localized AudioClip for entity '{_entityName}' was not preloaded; " +
                     $"resolving synchronously will block the main thread. " +
-                    $"Call {nameof(SoundManager)}.{nameof(SoundManager.PreloadLocalizationAssets)}(SoundID) before playback to avoid hitches.");
+                    $"Call {nameof(BroAudio)}.{nameof(BroAudio.LoadAssetAsync)}(SoundID) before playback to avoid hitches.");
             }
             var resolvedClip = handle.WaitForCompletion();
             var selectedLocale = LocalizationSettings.SelectedLocale;


### PR DESCRIPTION
## Summary
Refactors the localization asset loading system to use the same public API as addressables (`LoadAssetAsync`, `LoadAllAssetsAsync`, `ReleaseAsset`, `ReleaseAllAssets`) instead of separate `PreloadLocalizationAssets` and `ReleaseLocalizationPreload` methods. This simplifies the API surface and provides a unified interface for asset management regardless of the underlying loading mechanism.

## Key Changes

- **Removed public localization-specific methods**: Deleted `PreloadLocalizationAssets()` and `ReleaseLocalizationPreload()` from both `BroAudio` and `SoundManager`
- **Made localization methods private**: Converted `PreloadLocalizationAssets()` to `LoadLocalizedAssetAsync()` and created `LoadAllLocalizedAssetsAsync()` as internal implementation details
- **Unified asset loading**: Modified `LoadAssetAsync()` and `LoadAllAssetsAsync()` in `SoundManager.Addressables.cs` to detect and handle localization-mode entities automatically
- **Unified asset release**: Modified `ReleaseAsset()` and `ReleaseAllAssets()` to handle localization entities through the same code paths
- **Updated documentation**: Clarified in public API docs that localization mode entities are supported and that `clipIndex` is ignored for localization playback
- **Expanded conditional compilation**: Changed `#if PACKAGE_ADDRESSABLES` to `#if PACKAGE_ADDRESSABLES || PACKAGE_LOCALIZATION` in relevant sections to ensure localization support is available
- **Updated warning messages**: Changed user-facing warnings to reference the new unified API (`BroAudio.LoadAssetAsync`) instead of the removed `PreloadLocalizationAssets`

## Implementation Details

- Localization entities are now detected within the addressables loading methods using `PlayMode == MulticlipsPlayMode.Localization` checks
- The cache validation logic was improved to return cached handles if they're still valid, avoiding unnecessary reloads
- Locale change subscriptions are still managed internally and automatically when localization assets are first loaded
- The implementation maintains backward compatibility for addressables-only workflows while seamlessly integrating localization support

https://claude.ai/code/session_011y989fXQguHLJCdtMUoGPL