### PR TITLE
Enforce Addressables requirement for Localization mode

### DIFF
--- a/Assets/BroAudio/Editor/EntityPropertyDrawer/AudioEntityEditor.cs
+++ b/Assets/BroAudio/Editor/EntityPropertyDrawer/AudioEntityEditor.cs
@@ -308,6 +308,26 @@ namespace Ami.BroAudio.Editor
             SerializedProperty useAddressablesProp = serializedObject.FindProperty(nameof(AudioEntity.UseAddressables));
             Rect rect = GetRectAndIterateLine(position);
             Rect toggleRect = new Rect(rect) { width = 100f, x = position.xMax - 100f };
+
+#if PACKAGE_LOCALIZATION
+            var playModeProp = serializedObject.FindProperty(AudioEntity.EditorPropertyName.MulticlipsPlayMode);
+            if (playModeProp != null && (MulticlipsPlayMode)playModeProp.enumValueIndex == MulticlipsPlayMode.Localization)
+            {
+                if (!useAddressablesProp.boolValue)
+                {
+                    useAddressablesProp.boolValue = true;
+                }
+
+                var lockedContent = new GUIContent("Addressables",
+                    "Locked on while in Localization mode — Unity Localization requires Addressables.");
+                using (new EditorGUI.DisabledScope(true))
+                {
+                    EditorGUI.ToggleLeft(toggleRect, lockedContent, true);
+                }
+                return;
+            }
+#endif
+
             EditorGUI.BeginChangeCheck();
             useAddressablesProp.boolValue = EditorGUI.ToggleLeft(toggleRect, "Addressables", useAddressablesProp.boolValue);
             if (EditorGUI.EndChangeCheck())

--- a/Assets/BroAudio/Editor/EntityPropertyDrawer/ReorderableClips.Localization.cs
+++ b/Assets/BroAudio/Editor/EntityPropertyDrawer/ReorderableClips.Localization.cs
@@ -73,7 +73,7 @@ namespace Ami.BroAudio.Editor
         {
             bool confirmed = EditorUtility.DisplayDialog(
                 "Switch to Localization Mode",
-                "Switching to Localization mode will clear all AudioClip references and clip properties on this entity. Continue?",
+                "Switching to Localization mode will clear all AudioClip references and clip properties on this entity, and force-enable Addressables for this entity. Continue?",
                 "Yes",
                 "No");
 
@@ -84,6 +84,13 @@ namespace Ami.BroAudio.Editor
                 {
                     ResetBroAudioClipSerializedProperties(clipsProp.GetArrayElementAtIndex(i));
                 }
+
+                var useAddressablesProp = clipsProp.serializedObject.FindProperty(nameof(AudioEntity.UseAddressables));
+                if (useAddressablesProp != null)
+                {
+                    useAddressablesProp.boolValue = true;
+                }
+
                 clipsProp.serializedObject.ApplyModifiedProperties();
             }
             return confirmed;
@@ -343,6 +350,8 @@ namespace Ami.BroAudio.Editor
                 }
             }
 
+            HandleLocalizationClipDragAndDrop(clipRect, localeCode);
+
             EditorGUI.BeginChangeCheck();
             var newClip = EditorGUI.ObjectField(clipRect, currentClip, typeof(AudioClip), false) as AudioClip;
             if (EditorGUI.EndChangeCheck())
@@ -369,6 +378,43 @@ namespace Ami.BroAudio.Editor
         private float GetLocalizationElementHeight(int index)
         {
             return EditorGUIUtility.singleLineHeight + 4f;
+        }
+
+        private void HandleLocalizationClipDragAndDrop(Rect dropRect, string localeCode)
+        {
+            var evt = Event.current;
+            if (evt.type != EventType.DragUpdated && evt.type != EventType.DragPerform)
+            {
+                return;
+            }
+
+            if (!dropRect.Contains(evt.mousePosition))
+            {
+                return;
+            }
+
+            AudioClip dragged = null;
+            foreach (var obj in DragAndDrop.objectReferences)
+            {
+                if (obj is AudioClip clip)
+                {
+                    dragged = clip;
+                    break;
+                }
+            }
+
+            if (dragged == null)
+            {
+                return;
+            }
+
+            DragAndDrop.visualMode = DragAndDropVisualMode.Copy;
+            if (evt.type == EventType.DragPerform)
+            {
+                DragAndDrop.AcceptDrag();
+                TrySetClipInTable(localeCode, dragged);
+                evt.Use();
+            }
         }
 
         private SerializedProperty GetLocalizationCurrentSelectedClip()
@@ -695,18 +741,24 @@ namespace Ami.BroAudio.Editor
                 return;
             }
 
-            string guid = clip != null ? AssetDatabase.AssetPathToGUID(AssetDatabase.GetAssetPath(clip)) : string.Empty;
+            Undo.RecordObject(table, "Set Localized Audio Clip");
+
             var entry = table.GetEntry(entryKey);
-            if (entry == null)
+            if (entry != null && !string.IsNullOrEmpty(entry.Guid))
             {
-                tableCollection.AddAssetToTable(table, entryKey, clip);
+                tableCollection.RemoveAssetFromTable(table, entryKey, createUndo: true);
             }
-            else
+
+            if (clip != null)
             {
-                entry.Guid = guid;
+                tableCollection.AddAssetToTable(table, entryKey, clip, createUndo: true);
             }
 
             EditorUtility.SetDirty(table);
+            if (tableCollection.SharedData != null)
+            {
+                EditorUtility.SetDirty(tableCollection.SharedData);
+            }
             AssetDatabase.SaveAssets();
         }
     }


### PR DESCRIPTION
## Summary
This PR ensures that Addressables is automatically enabled when using Localization mode, since Unity Localization requires Addressables to function. It also improves the localization clip assignment workflow by adding drag-and-drop support and refining the table management logic.

## Key Changes

- **Auto-enable Addressables in Localization mode**: When switching to Localization mode, the `UseAddressables` property is now force-enabled since it's a requirement for Unity Localization
- **Lock Addressables toggle in Localization mode**: The Addressables toggle is disabled and locked when Localization mode is active, preventing users from accidentally disabling it
- **Add drag-and-drop support**: Implemented `HandleLocalizationClipDragAndDrop()` to allow users to drag AudioClips directly onto localization clip fields
- **Improve localization table management**: Refactored `TrySetClipInTable()` to properly handle asset removal before reassignment and ensure proper undo/dirty state tracking
- **Update confirmation dialog**: Modified the switch-to-Localization confirmation message to inform users that Addressables will be force-enabled

## Implementation Details

- The drag-and-drop handler checks for `AudioClip` objects in the drag payload and validates the drop zone before accepting
- Table entry updates now use `RemoveAssetFromTable()` before `AddAssetToTable()` to ensure clean state transitions
- Added proper `Undo.RecordObject()` calls and `EditorUtility.SetDirty()` for both the table and its SharedData to maintain asset integrity
- The Addressables toggle lock is only applied when the `PACKAGE_LOCALIZATION` preprocessor symbol is defined, maintaining backward compatibility

https://claude.ai/code/session_01SQzgMqFs1Mr3mpYhzcL2K3