### PR TITLE
Rename localization subscription methods for consistency

### DIFF
--- a/Assets/BroAudio/Runtime/BroAudio.cs
+++ b/Assets/BroAudio/Runtime/BroAudio.cs
@@ -360,15 +360,15 @@ namespace Ami.BroAudio
         /// Subscribes to localized clip changes for a Localization-mode entity, identified by <see cref="SoundID"/>.
         /// Uses <c>LocalizedAsset&lt;T&gt;.AssetChanged</c> under the hood, so behavior matches Unity Localization's standard asset-change notification.
         /// </summary>
-        public static void SubscribeLocalizedClipChanged(SoundID id, Action<SoundID> handler)
+        public static void SubscribeLocalizedAudioChanged(SoundID id, Action<SoundID> handler)
             => Manager?.SubscribeLocalizedAudioChanged(id, handler);
 
         /// <summary>
-        /// Removes a handler previously registered with <see cref="SubscribeLocalizedClipChanged"/>.
+        /// Removes a handler previously registered with <see cref="SubscribeLocalizedAudioChanged"/>.
         /// Unsubscribing the last handler for an <paramref name="id"/> causes Unity Localization to release the
         /// underlying Addressables handle automatically.
         /// </summary>
-        public static void UnsubscribeLocalizedClipChanged(SoundID id, Action<SoundID> handler)
+        public static void UnsubscribeLocalizedAudioChanged(SoundID id, Action<SoundID> handler)
             => Manager?.UnsubscribeLocalizedAudioChanged(id, handler);
         
         /// <summary>

--- a/Assets/BroAudio/Runtime/SoundManager/SoundManager.Localization.cs
+++ b/Assets/BroAudio/Runtime/SoundManager/SoundManager.Localization.cs
@@ -161,7 +161,7 @@ namespace Ami.BroAudio.Runtime
             if (!TryGetLocalizationEntity(id, out var entity))
             {
                 Debug.LogWarning(Utility.LogTitle +
-                    $"SubscribeLocalizedClipChanged: entity for SoundID '{id}' is not in Localization mode.");
+                    $"SubscribeLocalizedAudioChanged: entity for SoundID '{id}' is not in Localization mode.");
                 return;
             }
 

--- a/Assets/BroAudio/Runtime/Utility/ClipSelection/SequenceClipStrategy.cs
+++ b/Assets/BroAudio/Runtime/Utility/ClipSelection/SequenceClipStrategy.cs
@@ -59,9 +59,8 @@ namespace Ami.BroAudio.Runtime
         {
             _namedSequenceIndices ??= new Dictionary<string, int>();
 
-            _namedSequenceIndices.TryGetValue(sequenceId, out int seqIndex);
-            // TryGetValue returns 0 for missing keys; we use -1 as uninitialized, so default to -1
-            if (!_namedSequenceIndices.ContainsKey(sequenceId))
+            // TryGetValue yields 0 for missing keys; we use -1 as uninitialized, so default to -1.
+            if (!_namedSequenceIndices.TryGetValue(sequenceId, out int seqIndex))
             {
                 seqIndex = -1;
             }

--- a/Docs/RELEASE_NOTES.md
+++ b/Docs/RELEASE_NOTES.md
@@ -23,7 +23,7 @@ tables.
 - **`SubscribeLocalizedAudioChanged` / `UnsubscribeLocalizedAudioChanged`**
   runtime events for reacting to locale-driven clip changes.
 - Library Manager additions:
-    - **"Open Localization Table"** button on the reorderable clip list.
+    - **"Open Localization Tables"** button on the reorderable clip list.
     - Inline locale **table / entry dropdowns** integrated as the first
       row of the clip list.
     - Confirmation dialog when switching an existing entity into
@@ -49,7 +49,8 @@ tables.
 
 ### Editor / Tooling
 - BroAudio editor windows are now also accessible under
-  **Window ▸ Audio**, alongside the existing **Tools ▸ BroAudio** menu.
+  **Window ▸ Audio ▸ BroAudio**, alongside the existing
+  **Tools ▸ BroAudio** menu.
 - The **Play Mode** dropdown is now always visible in the Library
   Manager.
 


### PR DESCRIPTION
## Summary
This PR renames localization-related subscription methods and fixes associated documentation and error messages to use consistent naming conventions throughout the codebase.

## Key Changes
- **Method Renames**: 
  - `SubscribeLocalizedClipChanged` → `SubscribeLocalizedAudioChanged`
  - `UnsubscribeLocalizedClipChanged` → `UnsubscribeLocalizedAudioChanged`
  - Updated all references in public API, documentation, and error messages

- **Code Quality Improvements**:
  - Refactored `SequenceClipStrategy.SelectClipForNamedSequence()` to use `TryGetValue()` more idiomatically, eliminating redundant dictionary lookups
  - Improved code comment clarity in the sequence selection logic

- **Documentation Updates**:
  - Fixed release notes: "Open Localization Table" → "Open Localization Tables"
  - Corrected menu path documentation: "Window ▸ Audio" → "Window ▸ Audio ▸ BroAudio"
  - Updated XML documentation references to reflect new method names

## Implementation Details
The renaming aligns the API with the actual implementation which handles audio changes (not just clips), making the method names more semantically accurate. The `TryGetValue()` refactoring in `SequenceClipStrategy` eliminates an unnecessary `ContainsKey()` call, improving performance while maintaining the same logic for handling uninitialized sequence indices.

https://claude.ai/code/session_01R73QzE1n7EHCnqsSci6Nft