### PR TITLE
Fix follow-target playback to apply distance-based filtering

### DIFF
--- a/Assets/BroAudio/Runtime/Player/PlaybackPreference.cs
+++ b/Assets/BroAudio/Runtime/Player/PlaybackPreference.cs
@@ -43,6 +43,10 @@ namespace Ami.BroAudio.Runtime
         public PlaybackPreference(IAudioEntity entity, Transform followTarget) : this(entity)
         {
             _followTarget = followTarget;
+            // Leave _position unset so Position resolves from the live follow target each frame.
+            // Otherwise the base constructor's sentinel makes follow-target plays read as global,
+            // which bypasses the distance-based comb-filtering rule.
+            _position = null;
         }
 
         public PlaybackPreference(IAudioEntity entity)


### PR DESCRIPTION
## Summary
Fixed an issue where audio playback with a follow target was incorrectly treated as global playback, bypassing distance-based comb-filtering rules.

## Key Changes
- Modified `PlaybackPreference` constructor that accepts a follow target to explicitly set `_position` to `null`
- Added clarifying comments explaining that leaving `_position` unset allows the `Position` property to resolve from the live follow target each frame
- This prevents the base constructor's sentinel value from causing follow-target plays to be misidentified as global playback

## Implementation Details
The issue occurred because the follow-target constructor was relying on the base constructor's initialization, which set a sentinel position value. This caused the playback system to incorrectly classify follow-target audio as global, which in turn bypassed the distance-based comb-filtering logic. By explicitly setting `_position = null`, the `Position` property now correctly resolves dynamically from the follow target's current position each frame, ensuring proper distance-based audio filtering is applied.

https://claude.ai/code/session_011TYzQaB1omCEtnEz8rUSuC