### PR TITLE
Fix Unity 6 compatibility and simplify GUID validation

### DIFF
--- a/Assets/BroAudio/Editor/DevTools/BroAudioReflection.cs
+++ b/Assets/BroAudio/Editor/DevTools/BroAudioReflection.cs
@@ -257,7 +257,7 @@ namespace Ami.Extension.Reflection
             {
                 UnityEngine.Debug.LogError(Utility.LogTitle + $"Cast GUID failed! object :{obj}");
             }
-            return guid != default && !guid.Empty();
+            return guid != default(GUID);
         }
     }
 }

--- a/Assets/BroAudio/Editor/Utility/FieldUsageFinder.cs
+++ b/Assets/BroAudio/Editor/Utility/FieldUsageFinder.cs
@@ -207,9 +207,14 @@ public class FieldUsageFinder : EditorWindow
         return new MultiColumnHeaderState.Column
         {
             headerContent = new GUIContent(header),
+#if UNITY_6000_0_OR_NEWER
+            headerTextAlignment = TextAnchor.MiddleLeft,
+            sortingArrowAlignment = TextAnchor.MiddleCenter,
+#else
             headerTextAlignment = TextAlignment.Left,
-            sortedAscending = true,
             sortingArrowAlignment = TextAlignment.Center,
+#endif
+            sortedAscending = true,
             width = width,
             minWidth = 50,
             autoResize = true,


### PR DESCRIPTION
## Summary
This PR addresses Unity 6 compatibility issues and simplifies GUID validation logic in the BroAudio editor tools.

## Key Changes
- **FieldUsageFinder.cs**: Added conditional compilation to handle API differences between Unity 6 and earlier versions
  - Unity 6.0.0+: Uses `TextAnchor` enum for `headerTextAlignment` and `sortingArrowAlignment`
  - Earlier versions: Uses `TextAlignment` enum
  - Moved `sortedAscending` assignment outside the conditional block for clarity

- **BroAudioReflection.cs**: Simplified GUID validation logic
  - Replaced `guid != default && !guid.Empty()` with `guid != default(GUID)`
  - Removes redundant null/empty check by using direct default comparison

## Implementation Details
The changes ensure the editor tools work correctly across different Unity versions while maintaining the same functional behavior. The GUID validation simplification reduces code complexity without changing the validation semantics.

https://claude.ai/code/session_01LLYj2oL8tJ3SqYVWJx777V